### PR TITLE
refactor(core): many type fixes and improvements

### DIFF
--- a/packages/core/src/__tests__/index.ts
+++ b/packages/core/src/__tests__/index.ts
@@ -8,10 +8,11 @@ import {
   getTree,
   getIsAction,
   getIsAtom,
+  Unit
 } from '../index'
 import { initAction } from '../declareAtom'
 
-function noop() {}
+function noop() { }
 
 describe('@reatom/core', () => {
   describe('main api', () => {
@@ -19,7 +20,7 @@ describe('@reatom/core', () => {
       // @ts-ignore
       expect(getIsAction()).toBe(false)
       expect(getIsAction(null)).toBe(false)
-      expect(getIsAction({})).toBe(false)
+      expect(getIsAction({} as Unit<unknown>)).toBe(false)
       expect(getIsAction(declareAction())).toBe(true)
       expect(getIsAction(declareAtom(0, noop))).toBe(false)
     })
@@ -27,7 +28,7 @@ describe('@reatom/core', () => {
       // @ts-ignore
       expect(getIsAtom()).toBe(false)
       expect(getIsAtom(null)).toBe(false)
-      expect(getIsAtom({})).toBe(false)
+      expect(getIsAtom({} as Unit<unknown>)).toBe(false)
       expect(getIsAtom(declareAtom(0, noop))).toBe(true)
       expect(getIsAtom(declareAction())).toBe(false)
     })
@@ -53,7 +54,7 @@ describe('@reatom/core', () => {
     test('declareAtom', () => {
       const name = '_atomName_'
       const initialState = {}
-      const atom = declareAtom(name, initialState, () => {})
+      const atom = declareAtom(name, initialState, () => { })
       const state = atom({}, initAction)
 
       expect(getState(state, atom)).toBe(initialState)
@@ -63,7 +64,7 @@ describe('@reatom/core', () => {
           return keys.length === 1 && keys[0].includes(name)
         })(),
       ).toBe(true)
-      expect(declareAtom([name], initialState, () => {})()).toEqual({
+      expect(declareAtom([name], initialState, () => { })()).toEqual({
         [name]: initialState,
       })
     })
@@ -160,7 +161,7 @@ describe('@reatom/core', () => {
 
       expect(
         store.getState(root) !==
-          (store.dispatch(increment()), store.getState(root)),
+        (store.dispatch(increment()), store.getState(root)),
       ).toBe(true)
       expect(store.getState(root)).toEqual({
         count: 1,
@@ -215,7 +216,7 @@ describe('@reatom/core', () => {
 
       expect(
         store.getState(root) ===
-          (store.dispatch({ type: 'random', payload: null }),
+        (store.dispatch({ type: 'random', payload: null }),
           store.getState(root)),
       ).toBe(true)
       expect(storeSubscriber.mock.calls.length).toBe(3)
@@ -318,7 +319,7 @@ describe('@reatom/core', () => {
       expect(store.getState(count2)).toBe(0)
       expect(store.getState(count2Doubled)).toBe(0)
 
-      store.subscribe(count2Doubled, () => {})
+      store.subscribe(count2Doubled, () => { })
       store.dispatch(increment2())
       expect(store.getState(count2)).toBe(1)
       expect(store.getState(count2Doubled)).toBe(2)
@@ -341,7 +342,7 @@ describe('@reatom/core', () => {
       expect(store.getState(count)).toBe(1)
       expect(store.getState().countDoubled).toBe(undefined)
 
-      let unsubscriber = store.subscribe(countDoubled, () => {})
+      let unsubscriber = store.subscribe(countDoubled, () => { })
       store.dispatch(increment())
       expect(store.getState(count)).toBe(2)
       expect(store.getState().countDoubled).toBe(4)
@@ -351,7 +352,7 @@ describe('@reatom/core', () => {
       expect(store.getState(count)).toBe(3)
       expect(store.getState().countDoubled).toBe(undefined)
 
-      unsubscriber = store.subscribe(countDoubled, () => {})
+      unsubscriber = store.subscribe(countDoubled, () => { })
       store.dispatch(increment())
       expect(store.getState(count)).toBe(4)
       expect(store.getState().countDoubled).toBe(8)
@@ -367,7 +368,7 @@ describe('@reatom/core', () => {
 
       expect(store.getState(countStatic)).toBe(10)
 
-      store.subscribe(countStatic, () => {})
+      store.subscribe(countStatic, () => { })
       store.dispatch(increment())
 
       expect(store.getState(countStatic)).toBe(11)

--- a/packages/core/src/createStore.ts
+++ b/packages/core/src/createStore.ts
@@ -1,18 +1,12 @@
-import { Leaf, Tree, State, TreeId, Ctx, createCtx } from './kernel'
+import { Tree, State, TreeId, createCtx, Action } from './kernel'
 import {
-  TREE,
-  noop,
-  nameToId,
-  Unit,
   throwError,
   getTree,
   safetyFunc,
-  getIsAction,
   assign,
   getIsAtom,
 } from './shared'
-import { Action, declareAction, ActionType } from './declareAction'
-import { Atom, declareAtom, initAction, map, getState } from './declareAtom'
+import { Atom, declareAtom, initAction, getState } from './declareAtom'
 
 // for create nullable store
 const defaultAtom = declareAtom(0, () => 0)
@@ -117,7 +111,7 @@ export function createStore(
   }
 
   function dispatch(action: Action<any>) {
-    ;(typeof action !== 'object' ||
+    (typeof action !== 'object' ||
       action === null ||
       typeof action.type !== 'string') &&
       throwError('Invalid action')
@@ -125,13 +119,13 @@ export function createStore(
     const ctx = createCtx(state, action)
     storeTree.forEach(action.type, ctx)
 
-    const { changedIds, stateNew } = ctx
+    const { changedTreeIds, stateNew } = ctx
 
-    if (changedIds.length > 0) {
+    if (changedTreeIds.length > 0) {
       assign(state, stateNew)
 
-      for (let i = 0; i < changedIds.length; i++) {
-        const id = changedIds[i]
+      for (let i = 0; i < changedTreeIds.length; i++) {
+        const id = changedTreeIds[i]
         callFromList(listenersStore.get(id) || [], stateNew[id])
       }
     }

--- a/packages/core/src/declareAction.ts
+++ b/packages/core/src/declareAction.ts
@@ -1,23 +1,23 @@
 import { Leaf, Action, Tree } from './kernel'
 import { TREE, noop, nameToId } from './shared'
 
-export type ActionCreator<Payload = undefined, TType extends Leaf = Leaf> = {
+export type ActionCreator<TPayload = undefined, TType extends Leaf = Leaf> = {
   getType: () => string
   [TREE]: Tree
-} & (Payload extends undefined
-  ? () => Action<Payload, TType>
-  : (payload: Payload) => Action<Payload, TType>)
+} & (TPayload extends undefined
+  ? () => Action<TPayload, TType>
+  : (payload: TPayload) => Action<TPayload, TType>)
 
 export function declareAction<
-  Payload = undefined,
+  TPayload = undefined,
   TType extends Leaf = Leaf
->(name: string | [TType] = 'action'): ActionCreator<Payload, TType> {
+>(name: string | [TType] = 'action'): ActionCreator<TPayload, TType> {
   const id = nameToId(name)
 
   const ACTree = new Tree(id, true)
   ACTree.addFn(noop, id)
 
-  function actionCreator(payload?: Payload) {
+  function actionCreator(payload?: TPayload) {
     return {
       type: id,
       payload,

--- a/packages/core/src/declareAction.ts
+++ b/packages/core/src/declareAction.ts
@@ -1,24 +1,17 @@
-import { Leaf, Tree } from './kernel'
+import { Leaf, Action, Tree } from './kernel'
 import { TREE, noop, nameToId } from './shared'
 
-export type ActionType = Leaf
-
-export type Action<Payload, Type extends ActionType = string> = {
-  type: Type
-  payload: Payload
-}
-
-export type ActionCreator<Payload = undefined, Type extends string = string> = {
+export type ActionCreator<Payload = undefined, TType extends Leaf = Leaf> = {
   getType: () => string
   [TREE]: Tree
 } & (Payload extends undefined
-  ? () => Action<Payload, Type>
-  : (payload: Payload) => Action<Payload, Type>)
+  ? () => Action<Payload, TType>
+  : (payload: Payload) => Action<Payload, TType>)
 
 export function declareAction<
   Payload = undefined,
-  Type extends ActionType = string
->(name: string | [Type] = 'action'): ActionCreator<Payload, Type> {
+  TType extends Leaf = Leaf
+>(name: string | [TType] = 'action'): ActionCreator<Payload, TType> {
   const id = nameToId(name)
 
   const ACTree = new Tree(id, true)

--- a/packages/core/src/declareAtom.ts
+++ b/packages/core/src/declareAtom.ts
@@ -8,6 +8,7 @@ import {
   safetyFunc,
   getIsAction,
   assign,
+  Dictionary,
 } from './shared'
 import { declareAction } from './declareAction'
 
@@ -158,15 +159,15 @@ export function getState<T>(state: State, atom: Atom<T>): T | undefined {
 }
 
 // @ts-ignore
-export declare function map<T, _T = unknown>(
-  atom: Atom<_T>,
-  mapper: (dependedAtomState: _T) => T,
+export declare function map<T, U = unknown>(
+  atom: Atom<U>,
+  mapper: (dependedAtomState: U) => T,
 ): Atom<T>
 // @ts-ignore
-export declare function map<T, _T = unknown>(
+export declare function map<T, U = unknown>(
   name: string | [TreeId],
-  atom: Atom<_T>,
-  mapper: (dependedAtomState: _T) => T,
+  atom: Atom<U>,
+  mapper: (dependedAtomState: U) => T,
 ): Atom<T>
 // @ts-ignore
 export function map(name, target, mapper) {
@@ -188,17 +189,17 @@ export function map(name, target, mapper) {
 
 // @ts-ignore
 export declare function combine<
-  T extends { [key in string]: Atom<any> } | TupleOfAtoms
+  T extends Dictionary<Atom<any>> | TupleOfAtoms
 >(
   shape: T,
-): Atom<{ [key in keyof T]: T[key] extends Atom<infer S> ? S : never }>
+): Atom<{ [P in keyof T]: T[P] extends Atom<infer S> ? S : never }>
 // @ts-ignore
 export declare function combine<
-  T extends { [key in string]: Atom<any> } | TupleOfAtoms
+  T extends Dictionary<Atom<any>> | TupleOfAtoms
 >(
   name: string | [TreeId],
   shape: T,
-): Atom<{ [key in keyof T]: T[key] extends Atom<infer S> ? S : never }>
+): Atom<{ [P in keyof T]: T[P] extends Atom<infer S> ? S : never }>
 export function combine(name: any, shape: any) {
   let keys: string[]
   if (arguments.length === 1) {

--- a/packages/core/src/kernel.ts
+++ b/packages/core/src/kernel.ts
@@ -2,35 +2,49 @@ export type Leaf = string // unique
 export type TreeId = string // unique
 export type State = Record<TreeId, any>
 // reatom specific
-export type Fn = (ctx: Ctx) => any
-export type Ctx = ReturnType<typeof createCtx>
-export function createCtx(
+export type AtomUpdater = <TPayload>(ctx: Ctx<TPayload>) => void
+export type Action<TPayload = undefined, TType extends Leaf = Leaf> = {
+  type: TType;
+  payload: TPayload
+}
+export type Ctx<TPayload> = {
+  state: State;
+  stateNew: State;
+  type: Leaf;
+  payload: TPayload;
+  changedTreeIds: TreeId[];
+}
+interface ISetCounted {
+  add(f: AtomUpdater): void;
+  delete(f: AtomUpdater): void;
+  forEach(cb: (f: AtomUpdater) => any): void;
+}
+export function createCtx<TPayload>(
   state: State,
-  { type, payload }: { type: Leaf; payload: any },
-) {
+  { type, payload }: Action<TPayload>,
+): Ctx<TPayload> {
   return {
     state,
-    stateNew: {} as State,
+    stateNew: {},
     type,
     payload,
-    changedIds: [] as TreeId[],
+    changedTreeIds: [],
   }
 }
 // TODO: try to replace by class
-type SetCounted = ReturnType<typeof createSetCounted>
-function createSetCounted() {
-  const _counter = new Map<Fn, number>()
+function createSetCounted(): ISetCounted {
+  const _counter = new Map<AtomUpdater, number>()
 
   return {
-    add(el: Fn) {
+    add(el: AtomUpdater) {
       _counter.set(el, (_counter.get(el) || 0) + 1)
     },
-    delete(el: Fn) {
+    delete(el: AtomUpdater) {
       const count = _counter.get(el)
       if (count === 1) _counter.delete(el)
       else if (count! > 1) _counter.set(el, count! - 1)
     },
-    forEach(cb: (fn: Fn) => any) {
+    forEach(cb: (fn: AtomUpdater) => any) {
       _counter.forEach((_, fn) => cb(fn))
     },
   }
@@ -39,24 +53,28 @@ function createSetCounted() {
 export class Tree {
   id: TreeId
   isLeaf: boolean
-  fnsMap: Map<Leaf, SetCounted>
+  fnsMap: Map<Leaf, ISetCounted>
   constructor(id: TreeId, isLeaf = false) {
     this.id = id
     this.isLeaf = isLeaf
     this.fnsMap = new Map()
   }
   _getFns(key: Leaf) {
-    return (
-      this.fnsMap.get(key) ||
-      (this.fnsMap.set(key, createSetCounted()).get(key) as SetCounted)
-    )
+    let counted = this.fnsMap.get(key);
+
+    if (!counted) {
+      counted = createSetCounted();
+      this.fnsMap.set(key, counted);
+    }
+
+    return counted;
   }
   _manageFns(tree: Tree, type: 'add' | 'delete') {
     tree.fnsMap.forEach((set, key) => {
       set.forEach(this._getFns(key)[type])
     })
   }
-  addFn(fn: Fn, key: Leaf) {
+  addFn(fn: AtomUpdater, key: Leaf) {
     this._getFns(key).add(fn)
   }
   union(tree: Tree) {
@@ -65,7 +83,7 @@ export class Tree {
   disunion(tree: Tree) {
     this._manageFns(tree, 'delete')
   }
-  forEach(key: Leaf, ctx: Ctx) {
+  forEach(key: Leaf, ctx: Ctx<any>) {
     const setCounted = this.fnsMap.get(key)
     if (setCounted) setCounted.forEach(fn => fn(ctx))
   }

--- a/packages/core/src/shared.ts
+++ b/packages/core/src/shared.ts
@@ -2,6 +2,7 @@ import { Tree, TreeId, Leaf } from './kernel'
 import { ActionCreator } from './declareAction'
 import { Atom } from './declareAtom'
 
+export type Dictionary<TValue> = { [key: string]: TValue }
 export type Unit<T> = ActionCreator<T> | Atom<T>
 
 export const TREE = Symbol('@@Reatom/TREE')

--- a/packages/core/src/shared.ts
+++ b/packages/core/src/shared.ts
@@ -1,31 +1,31 @@
-import { Tree, TreeId } from './kernel'
+import { Tree, TreeId, Leaf } from './kernel'
 import { ActionCreator } from './declareAction'
 import { Atom } from './declareAtom'
 
-export type Unit<T = unknown> = (ActionCreator<T>) | (Atom<T>)
+export type Unit<T> = ActionCreator<T> | Atom<T>
 
 export const TREE = Symbol('@@Reatom/TREE')
 
-export function noop() {}
+export function noop() { }
 
 export const assign = Object.assign
 
-export function getTree(thing: Unit): Tree {
+export function getTree<T>(thing: Unit<T>): Tree {
   return thing && thing[TREE]
 }
 
-export function getIsAtom(thing: any): thing is Atom<any> {
+export function getIsAtom<T>(thing: Unit<T>): thing is Atom<T> {
   const vertex = getTree(thing)
   return Boolean(vertex && !vertex.isLeaf)
 }
 
-export function getIsAction(thing: any): thing is Atom<any> {
-  const vertex = getTree(thing)
-  return Boolean(vertex && vertex.isLeaf)
+export function getIsAction<T>(thing: Unit<T>): thing is ActionCreator<T> {
+  const tree = getTree(thing)
+  return Boolean(tree && tree.isLeaf)
 }
 
 let id = 0
-export function nameToId(name: string | [string]): TreeId {
+export function nameToId<T extends Leaf>(name: string | [T]): TreeId {
   return Array.isArray(name)
     ? safetyStr(name[0], 'name')
     : `${safetyStr(name, 'name')} [${++id}]`
@@ -39,7 +39,7 @@ export function safetyStr(str: string, name: string): string {
   if (typeof str !== 'string' || str.length === 0) throwError(`Invalid ${name}`)
   return str
 }
-export function safetyFunc(func: unknown, name: string) {
+export function safetyFunc(func: Function, name: string): Function {
   if (typeof func !== 'function') throwError(`Invalid ${name}`)
-  return func as Function
+  return func
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,7 +8,7 @@ import {
   MutableRefObject,
 } from 'react'
 
-import { Store, Atom, ActionCreator, getIsAtom } from '@reatom/core'
+import { Store, Atom, ActionCreator, getIsAtom, Unit } from '@reatom/core'
 
 function noop() {}
 
@@ -51,7 +51,7 @@ export function useAtom<T>(
   }, [])
 
   if (!atomRef.current) {
-    atomRef.current = getIsAtom(atom)
+    atomRef.current = getIsAtom(atom as Unit<T>)
       ? (atom as Atom<T>)
       : (atom as () => Atom<T>)()
     unsubscribeRef.current = store.subscribe(


### PR DESCRIPTION
add `Reducer` type
add `Reduce` type
add `DependencyMatcher`
add `T` prefix for generics
add `Dictionary` type
rename type `Fn` to `AtomUpdater`
rename `Ctx.changedIds` to `changedTreeIds`
replace `ActionType` with `Leaf`
make `Ctx` type static declared and provide `TPayload` generic
fix type guards `getTree`, `getIsAtom`, `getIsAction`