### PR TITLE
allow reatom/react depend from reatom/core@1.1.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
     "update": "npx npm-check-updates -u"
   },
   "peerDependencies": {
-    "@reatom/core": "1.0.0",
+    "@reatom/core": "^1.0.0",
     "react": "^16.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
After upgrade to @reatom/core@1.1.0 yarn shows a warning:
```
warning " > @reatom/react@1.0.0" has incorrect peer dependency "@reatom/core@1.0.0".
```

PR fixes this.