### PR TITLE
fix tests on windows host

### DIFF
--- a/packages/babel-plugin/test/index.spec.js
+++ b/packages/babel-plugin/test/index.spec.js
@@ -7,4 +7,5 @@ const path = require('path')
 pluginTester({
   plugin,
   fixtures: path.join(__dirname, 'fixtures'),
+  endOfLine: 'auto',
 })


### PR DESCRIPTION
`git clone` replace all LF to CRLF by default on a Windows machine. https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_formatting_and_whitespace

`babel-plugin-tester` use LF line endings by default. https://github.com/babel-utils/babel-plugin-tester#endofline

Therefore all babel-plugin tests are failed. This PR adds autodetect for `babel-plugin-tester` to cover 99% of reatom contributors.