### PR TITLE
Remove irrelevant keywords from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "reactive",
     "reactivity",
     "redux",
-    "effector",
-    "mobx",
     "state-manager",
     "state manager"
   ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,8 +56,6 @@
     "reactive",
     "reactivity",
     "redux",
-    "effector",
-    "mobx",
     "state-manager",
     "state manager",
     "reatom"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,8 +66,6 @@
     "reactive",
     "reactivity",
     "redux",
-    "effector",
-    "mobx",
     "state-manager",
     "state manager",
     "reatom",


### PR DESCRIPTION
`effector` and `mobx` keywords are irrelevant in the context of `reatom`, so they should be removed from there.