### PR TITLE
fix(react): useAtom forceUpdate for batching

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,7 +20,7 @@ export const { Provider } = context
 
 function useForceUpdate() {
   // dispatch don't have action and don't changes between rerenders
-  return useReducer<Reducer<boolean, null>>(s => !s, true)[1] as () => void
+  return useReducer<Reducer<boolean, null>>(s => s++, true)[1] as () => void
 }
 
 const lifeCycleStatus = {


### PR DESCRIPTION
Two actions for one atom doesn't caused rerender for component with one `useAtom`.