### PR TITLE
Use simple-git-hooks to validate commit message and format

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "homepage": "https://github.com/artalar/reatom/tree/v2",
   "devDependencies": {
+    "@commitlint/cli": "^13.1.0",
+    "@commitlint/config-conventional": "^13.1.0",
+    "@commitlint/config-lerna-scopes": "^13.1.0",
     "@jsdevtools/npm-publish": "^1.4.3",
     "@size-limit/preset-small-lib": "^4.11.0",
     "@types/jest": "^26.0.23",
@@ -30,10 +33,17 @@
     "microbundle": "^0.13.1",
     "prettier": "^2.3.0",
     "rimraf": "^3.0.2",
+    "simple-git-hooks": "^2.6.1",
     "size-limit": "^4.11.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2",
     "zx": "^4.1.1"
+  },
+  "lint-staged": {
+    "**/*.{js,ts,md}": "prettier --write"
+  }, 
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged && commitlint"
   },
   "keywords": [
     "state",


### PR DESCRIPTION
Content of this PR:

* Adds simple-git-hooks to manage git hooks
* Uses lint-staged to run prettier in files before commiting
* Validates commit messages using commitlint before commiting

I a saw lint-staged in a simple-git-hooks example and I decided to add to pre-commit as we're running commitlint. Tell me if you want to remove. There is a caveat in the time to download using `npx` but I think it's ok to ponder. Tell me if you want to remove.

I ran `git grep "husky"` and I didn't found any occurrences. I think you removed somewhere in the past.  

Fixes #360 