### PR TITLE
deps(npm-react): move react to peerDependencies

### DIFF
--- a/packages/npm-react/package.json
+++ b/packages/npm-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reatom/npm-react",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": false,
   "sideEffects": false,
   "description": "Reatom for npm-react",
@@ -24,7 +24,9 @@
   },
   "dependencies": {
     "@reatom/core": ">=3.1.0",
-    "@reatom/lens": ">=3.1.0",
+    "@reatom/lens": ">=3.1.0"
+  },
+  "peerDependencies": {
     "react": ">=16.8.0"
   },
   "author": "artalar",


### PR DESCRIPTION
у меня небольшая проблемка, в @reatom/npm-react есть зависимость"react": ">=16.8.0" из-за особенности сборки проекта (собираются несколько репозиториев в один большой портал) затаскивается 2 реакта и webpack не может разрулить какой из них использовать. Кажется правильнее всего держать такие зависимости в peerDependencies. 
peerDependencies не тянет пакет а просто предупредит о том что в проекте либо отсутствует пакет или версия не та, в случае реактом нет необходимости еще раз тащить пакет.