### PR TITLE
docs: pass `ctx` into `parseAtoms `

### DIFF
--- a/docs/src/pages/packages/lens.md
+++ b/docs/src/pages/packages/lens.md
@@ -177,7 +177,7 @@ Parse tree-like structure by replacing atoms by its values.
 import { parseAtoms } from '@reatom/lens'
 
 export const submit = action((ctx) => {
-  const data = parseAtoms({ titleAtom, commentsAtom })
+  const data = parseAtoms(ctx, { titleAtom, commentsAtom })
 
   return ctx.schedule(() => api.someSubmit(data))
 })


### PR DESCRIPTION
According to the ts definition we have to pass `ctx` as the first parameter
https://github.com/artalar/reatom/blob/v3/packages/lens/src/parseAtoms.ts#L16