### PR TITLE
bug: main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Reatom is the ultimate [state manager](/general/what-is-state-manager) with quit
 
 Key principles are **immutability** and **explicit reactivity** (no proxies), implicit **DI** and actor-like **lifecycle hooks**. All this with simple API and **automatic type inference**.
 
-[The core package](/core) includes all these features and you may use it anywhere, from huge apps to even small libs, as the overhead is only [2 KB](https://bundlejs.com/?q=%40reatom%2Fcore). Also, you could reuse our carefully written [helper tools](/packages/framework) to solve complex tasks in a couple lines of code. We are trying to build a stable and balanced ecosystem for perfect DX and predictable maintains even for years ahead.
+[The core package](/packages/core) includes all these features and you may use it anywhere, from huge apps to even small libs, as the overhead is only [2 KB](https://bundlejs.com/?q=%40reatom%2Fcore). Also, you could reuse our carefully written [helper tools](/packages/framework) to solve complex tasks in a couple lines of code. We are trying to build a stable and balanced ecosystem for perfect DX and predictable maintains even for years ahead.
 
 Do you use React.js? Check out [npm-react](/packages/npm-react) package!
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Reatom is the ultimate [state manager](/general/what-is-state-manager) with quit
 
 Key principles are **immutability** and **explicit reactivity** (no proxies), implicit **DI** and actor-like **lifecycle hooks**. All this with simple API and **automatic type inference**.
 
-[The core package](/packages/core) includes all these features and you may use it anywhere, from huge apps to even small libs, as the overhead is only [2 KB](https://bundlejs.com/?q=%40reatom%2Fcore). Also, you could reuse our carefully written [helper tools](/packages/framework) to solve complex tasks in a couple lines of code. We are trying to build a stable and balanced ecosystem for perfect DX and predictable maintains even for years ahead.
+[The core package](https://www.reatom.dev/core) includes all these features and you may use it anywhere, from huge apps to even small libs, as the overhead is only [2 KB](https://bundlejs.com/?q=%40reatom%2Fcore). Also, you could reuse our carefully written [helper tools](/packages/framework) to solve complex tasks in a couple lines of code. We are trying to build a stable and balanced ecosystem for perfect DX and predictable maintains even for years ahead.
 
 Do you use React.js? Check out [npm-react](/packages/npm-react) package!
 


### PR DESCRIPTION
Main problem is not in docs, but in main readme section))
It doesn't affect docs site

### reproduce
- go to https://github.com/artalar/reatom/tree/v3
- click on [The core package](https://github.com/artalar/reatom/blob/v3/core)

### result
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/26435684/221400445-075f8ab6-22c1-41b0-a3d5-e3eca88b6d40.png">
