### PR TITLE
Add examples for package naming convention

### DIFF
--- a/docs/src/pages/guides/naming.md
+++ b/docs/src/pages/guides/naming.md
@@ -6,7 +6,7 @@ description: Main advices for things naming
 
 ### Packages
 
-We want to grow a huge ecosystem of packages, which will be useful for everyone. So, it's crucial to have naming convention for packages, especially that a few different platforms could have a package with the same name. For this reason we use prefixes for adapter packages related to a specific scope. For example [`npm-history`](https://www.reatom.dev/packages/npm-history) for [history package](https://www.npmjs.com/package/history) adapter, `web-history` for potential [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) wrapper, and `node-http` for potential [Node HTTP](https://nodejs.org/docs/latest-v18.x/api/http.html) adapter. 
+We want to grow a huge ecosystem of packages, which will be useful for everyone. So, it's crucial to have naming convention for packages, especially when different platforms could have packages with the same name. For this reason we use prefixes for adapter packages related to a specific scope. For example [`npm-history`](https://www.reatom.dev/packages/npm-history) for [history package](https://www.npmjs.com/package/history) adapter, `web-history` for potential [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) wrapper, and `node-http` for potential [Node HTTP](https://nodejs.org/docs/latest-v18.x/api/http.html) adapter. 
 
 ### Fabric and model
 

--- a/docs/src/pages/guides/naming.md
+++ b/docs/src/pages/guides/naming.md
@@ -6,7 +6,7 @@ description: Main advices for things naming
 
 ### Packages
 
-We want to grow a huge ecosystem of packages, which will be useful for everyone. So, we need to have a common naming for packages, especially that a few different platforms could have a package with the same name. For this reason we use prefixes for adapter packages, which related to a specific scope, like `npm` or `web`, `node` etc.
+We want to grow a huge ecosystem of packages, which will be useful for everyone. So, it's crucial to have naming convention for packages, especially that a few different platforms could have a package with the same name. For this reason we use prefixes for adapter packages related to a specific scope. For example [`npm-history`](https://www.reatom.dev/packages/npm-history) for [history package](https://www.npmjs.com/package/history) adapter, `web-history` for potential [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) wrapper, and `node-http` for potential [Node HTTP](https://nodejs.org/docs/latest-v18.x/api/http.html) adapter. 
 
 ### Fabric and model
 


### PR DESCRIPTION
The package naming with examples were expressed in https://github.com/artalar/reatom/issues/422#issuecomment-1182480966