### PR TITLE
fix(async): #489 error in console

### DIFF
--- a/packages/async/src/withCache.ts
+++ b/packages/async/src/withCache.ts
@@ -137,7 +137,7 @@ export const withCache =
           () => cacheAtom.delete(ctx, key),
           staleTime,
         )
-        clearTimeoutId.toString = () => ''
+
         clearTimeoutId.unref?.()
         ctx.schedule(() => clearTimeout(clearTimeoutId), -1)
         const cache = cacheAtom.set(ctx, key, {


### PR DESCRIPTION
Hello,
Fix console error described in #489, just delete it because value assigned to primitive will be lost
