### PR TITLE
ci: fix release-please merge-commit titles parsing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "bootstrap-sha": "d7de33b868dd98b042dfc7ed9cf935b52bdd18c8",
+  "pull-request-title-pattern":"*INTENTIONALLY INVALID* for more info check https://github.com/googleapis/release-please/issues/1920",
   "packages": {
     "packages/all-settled": {},
     "packages/async": {},


### PR DESCRIPTION
Make pull-request-title-pattern unparsable so that it falls back to default merged pull request version by which title was originally generated.

Related:
 https://github.com/googleapis/release-please/issues/1920