### PR TITLE
fix(form-web): keep original element type

### DIFF
--- a/packages/form-web/src/index.ts
+++ b/packages/form-web/src/index.ts
@@ -144,7 +144,7 @@ export const withHtmlRegistration: {
   (fieldAtom: FieldAtom) => {
     const type = Array.isArray(fieldAtom.initState)
       ? 'select'
-      : ((attributes as HTMLInputAttributes).type ??= getType(
+      : ((attributes as HTMLInputAttributes).type ?? getType(
           fieldAtom.initState,
         ))
     const name = fieldAtom.__reatom.name?.replace('.dataAtom', '')


### PR DESCRIPTION
Currently `input` with `type: "password"` is impossible to use with form-web. Removed nullish coalescing assignment to keep original element type