### PR TITLE
ci: forward pull request command comment to review comment that will trigger CI

### DIFF
--- a/.github/workflows/forward-command.yml
+++ b/.github/workflows/forward-command.yml
@@ -1,0 +1,42 @@
+name: Forward comment with command to review comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  forward:
+    if: |
+      contains(github.event.comment.html_url, '/pull/') && 
+      startsWith(github.event.comment.body, '/') &&
+      contains(fromJSON(vars.COMMANDS_TO_FORWARD), github.event.comment.body)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    container:
+      image: node:${{vars.NODE_VERSION}}-alpine
+    steps:
+      - name: Get pull request branch
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+      - name: Remove original comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          script: |
+            github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+            });
+      - name: Create review comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          script: |
+            github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+              body: context.payload.comment.body,
+              event: "COMMENT"
+            });

--- a/.github/workflows/forward-command.yml
+++ b/.github/workflows/forward-command.yml
@@ -15,9 +15,6 @@ jobs:
     container:
       image: node:${{vars.NODE_VERSION}}-alpine
     steps:
-      - name: Get pull request branch
-        uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
       - name: Remove original comment
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
# Description:

This pr is aims to create a workflow which will be able to forward command comments in pr like `/prettify` to the review comments. Why do we need this forwarding? Simply because GitHub does not allow to listen `pull_request_comment` event and [force](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_comment-use-issue_comment) to use `issue_comment` event which will be triggered only when:

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

So it's means that all related workflows must be in the default branch to be visible for workflow run, this makes impossible to test new CI changes in pull request if they need to be triggered on comment. Why is it impossible? Because in the note tells us that workflow will be run on the default branch, but our changes are in pr, so they just don't exist in the default branch. Changing all the time default branch also not a good way. 

On which command workflow will be triggered is defined by a variable called `COMMANDS_TO_FORWARD`, example value: ["/prettify", “/release”]

All needed instruction is provided to @artalar 