### PR TITLE
fix: change type of dataAtom in withDataAtom operator without initState

### DIFF
--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -210,7 +210,7 @@ export const withDataAtom: {
     T extends AsyncAction & {
       dataAtom?: AsyncDataAtom<AsyncResp<T>>
     },
-  >(): Fn<[T], T & { dataAtom: AtomMut<undefined | AsyncResp<T>> }>
+  >(): Fn<[T], T & { dataAtom: AsyncDataAtom<AsyncResp<T> | undefined> }>
   <
     T extends AsyncAction & {
       dataAtom?: AsyncDataAtom<AsyncResp<T>>


### PR DESCRIPTION
fix #784 