### PR TITLE
fix: rename initState to computed in atom overload

### DIFF
--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -671,7 +671,7 @@ function onCall(this: Action, cb: Fn): Unsubscribe {
   })
 }
 
-export function atom<T>(callback: (ctx: CtxSpy) => T, name?: string): Atom<T>
+export function atom<T>(computed: (ctx: CtxSpy) => T, name?: string): Atom<T>
 export function atom<T>(initState: T, name?: string): AtomMut<T>
 export function atom<T>(
   initState: T | ((ctx: CtxSpy) => T),

--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -671,7 +671,7 @@ function onCall(this: Action, cb: Fn): Unsubscribe {
   })
 }
 
-export function atom<T>(initState: (ctx: CtxSpy) => T, name?: string): Atom<T>
+export function atom<T>(callback: (ctx: CtxSpy) => T, name?: string): Atom<T>
 export function atom<T>(initState: T, name?: string): AtomMut<T>
 export function atom<T>(
   initState: T | ((ctx: CtxSpy) => T),


### PR DESCRIPTION
Before

![IMG_20240422_033251_682.jpg](https://github.com/artalar/reatom/assets/41731334/b94527ff-a611-4efe-ad9f-a846b4231a0b)

After (callback is now computed, screenshots are old)

![IMG_20240422_033252_517.jpg](https://github.com/artalar/reatom/assets/41731334/f260e9b8-0dbe-4a85-9c98-9b3f2230fa92)


![IMG_20240422_033256_203.jpg](https://github.com/artalar/reatom/assets/41731334/a339054a-8c4d-42d3-b6c6-045c64860160)

