### PR TITLE
fix: adding initial state in historyAtom

### DIFF
--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -705,7 +705,7 @@ export function atom<T>(
     connectHooks: null,
     disconnectHooks: null,
     updateHooks: null,
-    actual: false
+    actual: false,
   }
 
   theAtom.pipe = pipe

--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -119,7 +119,6 @@ export interface AtomMut<State = any> extends Atom<State> {
 
 export interface AtomProto<State = any> {
   name: undefined | string
-  initValue: undefined | State
   isAction: boolean
   /** temporal cache of the last patch during transaction */
   patch: null | AtomCache
@@ -706,8 +705,7 @@ export function atom<T>(
     connectHooks: null,
     disconnectHooks: null,
     updateHooks: null,
-    actual: false,
-    initValue: initState
+    actual: false
   }
 
   theAtom.pipe = pipe

--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -119,6 +119,7 @@ export interface AtomMut<State = any> extends Atom<State> {
 
 export interface AtomProto<State = any> {
   name: undefined | string
+  initValue: undefined | State
   isAction: boolean
   /** temporal cache of the last patch during transaction */
   patch: null | AtomCache
@@ -706,6 +707,7 @@ export function atom<T>(
     disconnectHooks: null,
     updateHooks: null,
     actual: false,
+    initValue: initState
   }
 
   theAtom.pipe = pipe

--- a/packages/undo/src/index.test.ts
+++ b/packages/undo/src/index.test.ts
@@ -55,6 +55,18 @@ test('withUndo', async () => {
   ;('👍') //?
 })
 
+test('withUndo without getting historyAtom before first change', async () => {
+  const a = atom(0).pipe(withUndo({ length: 5 }))
+  const ctx = createTestCtx()
+
+  a(ctx, 1)
+  assert.is(ctx.get(a), 1)
+  assert.is(ctx.get(a.isUndoAtom), true)
+  assert.is(ctx.get(a.isRedoAtom), false)
+  assert.equal(ctx.get(a.historyAtom), [0, 1])
+  ;('👍') //?
+})
+
 test('limit', () => {
   const a = atom(0).pipe(withUndo({ length: 5 }))
   const ctx = createTestCtx()

--- a/packages/undo/src/index.ts
+++ b/packages/undo/src/index.ts
@@ -61,12 +61,12 @@ export const withUndo =
     throwReatomError(isAction(anAtom) || !isAtom(anAtom), 'atom expected')
 
     if (!anAtom.undo) {
-      const { name } = anAtom.__reatom
+      const { name, initValue } = anAtom.__reatom
 
-      const historyAtom = (anAtom.historyAtom = atom<Array<AtomState<T>>>(
-        [],
+      const historyAtom = anAtom.historyAtom = atom<Array<AtomState<T>>>(
+        [initValue],
         `${name}.Undo._historyAtom`,
-      ).pipe(withInit((ctx) => [ctx.get(anAtom)])))
+      )
 
       const positionAtom = (anAtom.positionAtom = atom(0, `${name}._position`))
 
@@ -94,7 +94,7 @@ export const withUndo =
       anAtom.redo = action((ctx) => jump(ctx, 1), `${name}.Undo.redo`)
 
       anAtom.clearHistory = action((ctx) => {
-        historyAtom(ctx, () => [ctx.get(anAtom)])
+        historyAtom(ctx, () => [initValue])
         positionAtom(ctx, 0)
       }, `${name}.Undo.clearHistory`)
 


### PR DESCRIPTION
fix https://github.com/artalar/reatom/issues/827

Problem in `withInit` of the historyAtom. Initial value doesn't set immediately.

I not found how to get initValue of atom without ctx for this reason I added in `__reatom ` prop initValue and set them in historyAtom