### PR TITLE
fix(persist-web-storage): fix cookie availability check

### DIFF
--- a/packages/persist-web-storage/src/reatomPersistCookie.ts
+++ b/packages/persist-web-storage/src/reatomPersistCookie.ts
@@ -107,7 +107,7 @@ export const reatomPersistCookie =
   }
 
 try {
-  var isCookieAvailable = !!globalThis.document.cookie
+  var isCookieAvailable = 'cookie' in globalThis.document
 } catch (error) {
   isCookieAvailable = false
 }


### PR DESCRIPTION
**Reasoning for Changes:**

The previous check for cookie availability could return an incorrect result if `globalThis.document.cookie` is an empty string. This has been fixed by using the `in` operator, which correctly checks for the presence of the `cookie` property in `globalThis.document`.
