### PR TITLE
fix(primitives): add the 'size' prop to reatomSet

### DIFF
--- a/packages/primitives/src/reatomSet.test.ts
+++ b/packages/primitives/src/reatomSet.test.ts
@@ -123,4 +123,11 @@ test(`reatomSet. isDisjointFrom`, () => {
   )
 })
 
+test(`reatomSet. size`, () => {
+  const ctx = createCtx()
+
+  assert.equal(reatomSet(new Set()).size(ctx), 0)
+  assert.equal(reatomSet(new Set([1, 2, 3])).size(ctx), 3)
+})
+
 test.run()

--- a/packages/primitives/src/reatomSet.ts
+++ b/packages/primitives/src/reatomSet.ts
@@ -15,6 +15,7 @@ export interface SetAtom<T> extends AtomMut<Set<T>> {
   isSubsetOf: (ctx: Ctx, set: Set<T>) => boolean
   isSupersetOf: (ctx: Ctx, set: Set<T>) => boolean
   isDisjointFrom: (ctx: Ctx, set: Set<T>) => boolean
+  size: (ctx: Ctx) => number
   /** @deprecated */
   set: Action<[el: T], Set<T>>
 }
@@ -98,5 +99,6 @@ export const reatomSet = <T>(
         (ctx.get(target) as ProposalSet<T>).isSupersetOf(set),
       isDisjointFrom: (ctx: Ctx, set: Set<T>) =>
         (ctx.get(target) as ProposalSet<T>).isDisjointFrom(set),
+      size: (ctx: Ctx) => ctx.get(target).size,
     })),
   )


### PR DESCRIPTION
The [reatomSet](https://github.com/artalar/reatom/blob/v3/packages/primitives/src/reatomSet.ts) doesn't have the 'size' prop that the original [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/size) has.

This PR adds the missing `size` prop.