### PR TITLE
fix(async): withAbort strategy first-in-win

### DIFF
--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -383,14 +383,10 @@ export const withAbort =
               })
             }
 
-            const pending = ctx.get(anAsync.pendingAtom)
-
-            if (strategy === 'first-in-win' && pending > 1) {
-              ctx.schedule(() => {
-                promise.controller.abort(
-                  toAbortError('concurrent request (first-in-win)'),
-                )
-              })
+            if (strategy === 'first-in-win' && ctx.get(anAsync.pendingAtom) > 1) {
+              promise.controller.abort(
+                toAbortError('concurrent request (first-in-win)'),
+              )
             }
 
             state = promise.controller

--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -373,7 +373,7 @@ export const withAbort =
           } = new AbortController(),
         ) => {
           ctx.spy(anAsync, ({ payload: promise }) => {
-            if (strategy === 'last-in-win' && state) {
+            if (strategy === 'last-in-win') {
               const controller = state
 
               ctx.schedule(() => {
@@ -383,11 +383,14 @@ export const withAbort =
               })
             }
 
-            if (strategy === 'first-in-win' && state && !state.settled) {
-              promise.controller.abort(
-                toAbortError('concurrent request (first-in-win)'),
-              )
-              return
+            const pending = ctx.get(anAsync.pendingAtom)
+
+            if (strategy === 'first-in-win' && pending > 1) {
+              ctx.schedule(() => {
+                promise.controller.abort(
+                  toAbortError('concurrent request (first-in-win)'),
+                )
+              })
             }
 
             state = promise.controller


### PR DESCRIPTION
https://github.com/artalar/reatom/issues/897

The changes solve two problems:
- The condition was always true for the `first-to-win` strategy
- Early return from a function does not allow adding an event `abort` handler