### PR TITLE
fix(url): add subpath parameter

### DIFF
--- a/packages/url/src/index.test.ts
+++ b/packages/url/src/index.test.ts
@@ -55,4 +55,28 @@ test('SearchParamsAtom.lens', () => {
   assert.is(ctx.get(urlAtom).href, 'http://example.com/path')
 })
 
+test('subpath SearchParamsAtom.lens', () => {
+  const ctx = createTestCtx()
+
+  setupUrlAtomSettings(ctx, () => new URL('http://example.com'))
+  const testAtom = searchParamsAtom.lens('test', {
+    parse: (value = '1') => Number(value),
+    subpath: () => '/results',
+  })
+
+  urlAtom.go(ctx, '/results')
+  testAtom(ctx, 2)
+  assert.is(ctx.get(testAtom), 2)
+  assert.is(ctx.get(urlAtom).href, 'http://example.com/results?test=2')
+
+  urlAtom.go(ctx, '/results')
+  testAtom(ctx, 3)
+  assert.is(ctx.get(urlAtom).href, 'http://example.com/results?test=3')
+
+  urlAtom.go(ctx, '/results')
+  testAtom(ctx, 1)
+  assert.is(ctx.get(testAtom), 1)
+  assert.is(ctx.get(urlAtom).href, 'http://example.com/results')
+})
+
 test.run()

--- a/packages/url/src/index.test.ts
+++ b/packages/url/src/index.test.ts
@@ -69,11 +69,11 @@ test('subpath SearchParamsAtom.lens', () => {
   assert.is(ctx.get(testAtom), 2)
   assert.is(ctx.get(urlAtom).href, 'http://example.com/results?test=2')
 
-  urlAtom.go(ctx, '/results')
+
   testAtom(ctx, 3)
   assert.is(ctx.get(urlAtom).href, 'http://example.com/results?test=3')
 
-  urlAtom.go(ctx, '/results')
+
   testAtom(ctx, 1)
   assert.is(ctx.get(testAtom), 1)
   assert.is(ctx.get(urlAtom).href, 'http://example.com/results')

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -257,7 +257,6 @@ export function withSearchParamsPersist(
       ctx.spy(searchParamsAtom, (next, prev) => {
         const currentPath = ctx.spy(urlAtom).pathname;
 
-        // Atualiza o estado apenas se o caminho estiver no subpath permitido
         if (subpath && currentPath.startsWith(subpath() as string)) {
           if (key in next) {
             if (!prev || prev[key] !== next[key]) {

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -179,7 +179,7 @@ const getSearchParamsOptions = (
           parse?: (value?: string) => unknown
           serialize?: (value: unknown) => undefined | string
           replace?: boolean
-          subpath?: (value?: string) => unknown;
+          subpath?: (value?: string) => unknown
         },
       ]
 ) => {
@@ -187,16 +187,13 @@ const getSearchParamsOptions = (
     parse = (value = '') => String(value),
     serialize = (value: any) => (value === init ? undefined : String(value)),
     replace,
-    subpath = (value: any) => String(value)
+    subpath = (value: any) => String(value),
   } = typeof a[0] === 'object'
     ? a[0]
     : {
         parse: a[0],
         serialize: a[1],
         replace: undefined,
-        
-        
-    
       }
   const init = parse()
   return {
@@ -211,16 +208,16 @@ export function withSearchParamsPersist<T = string>(
   key: string,
   parse?: (value?: string) => T,
   serialize?: (value: T) => undefined | string,
-): <A extends Atom<T>>(theAtom: A) => A;
+): <A extends Atom<T>>(theAtom: A) => A
 export function withSearchParamsPersist<T = string>(
   key: string,
   options: {
-    parse?: (value?: string) => T;
-    serialize?: (value: T) => undefined | string;
-    replace?: boolean;
-    subpath?: (value?: string) => unknown;
+    parse?: (value?: string) => T
+    serialize?: (value: T) => undefined | string
+    replace?: boolean
+    subpath?: (value?: string) => unknown
   },
-): <A extends Atom<T>>(theAtom: A) => A;
+): <A extends Atom<T>>(theAtom: A) => A
 
 export function withSearchParamsPersist(
   key: string,
@@ -228,53 +225,53 @@ export function withSearchParamsPersist(
     | [parse?: (value?: string) => unknown, serialize?: (value: unknown) => undefined | string]
     | [
         options: {
-          parse?: (value?: string) => unknown;
-          serialize?: (value?: unknown) => undefined | string;
-          replace?: boolean;
-          subpath?: (value?: string) => unknown;
+          parse?: (value?: string) => unknown
+          serialize?: (value?: unknown) => undefined | string
+          replace?: boolean
+          subpath?: (value?: string) => unknown
         },
       ]
 ) {
-  const { parse, serialize, replace, subpath } = getSearchParamsOptions(...a);
+  const { parse, serialize, replace, subpath } = getSearchParamsOptions(...a)
 
   return (theAtom: Atom) => {
-    const { computer, initState } = theAtom.__reatom;
+    const { computer, initState } = theAtom.__reatom
 
     theAtom.pipe(
       withInit((ctx, init) => {
-        const sp = ctx.get(searchParamsAtom);
-        const currentPath = ctx.get(urlAtom).pathname;
+        const sp = ctx.get(searchParamsAtom)
+        const currentPath = ctx.get(urlAtom).pathname
 
         if (subpath && !currentPath.startsWith(subpath() as string)) {
-          return init(ctx); 
+          return init(ctx)
         }
 
-        return key in sp ? parse(sp[key]) : init(ctx);
+        return key in sp ? parse(sp[key]) : init(ctx)
       }),
-    );
+    )
 
     theAtom.__reatom.computer = (ctx, state) => {
       ctx.spy(searchParamsAtom, (next, prev) => {
-        const currentPath = ctx.spy(urlAtom).pathname;
+        const currentPath = ctx.spy(urlAtom).pathname
 
         if (subpath && currentPath.startsWith(subpath() as string)) {
           if (key in next) {
             if (!prev || prev[key] !== next[key]) {
-              state = parse(next[key]);
+              state = parse(next[key])
             }
           } else {
             if (prev && key in prev) {
-              state = initState(ctx); 
+              state = initState(ctx)
             }
           }
         }
-      });
+      })
 
       if (computer) {
-        const { pubs } = ctx.cause;
+        const { pubs } = ctx.cause
 
-        const isInit = pubs.length === 0;
-        const hasOtherDeps = pubs.length > 1;
+        const isInit = pubs.length === 0
+        const hasOtherDeps = pubs.length > 1
 
         if (
           isInit ||
@@ -289,27 +286,27 @@ export function withSearchParamsPersist(
                 ),
             ))
         ) {
-          state = computer(ctx, state) as typeof state;
+          state = computer(ctx, state) as typeof state
         } else {
           for (let index = 1; index < pubs.length; index++) {
             // @ts-expect-error
-            ctx.spy({ __reatom: pubs[index]!.proto });
+            ctx.spy({ __reatom: pubs[index]!.proto })
           }
         }
       }
-      return state;
-    };
+      return state
+    }
 
     theAtom.onChange((ctx, state) => {
-      const value = serialize(state);
+      const value = serialize(state)
       if (value === undefined) {
-        searchParamsAtom.del(ctx, key, replace);
+        searchParamsAtom.del(ctx, key, replace)
       } else {
-        searchParamsAtom.set(ctx, key, value, replace);
+        searchParamsAtom.set(ctx, key, value, replace)
       }
-      ctx.get(theAtom);
-    });
+      ctx.get(theAtom)
+    })
 
-    return theAtom;
-  };
+    return theAtom
+  }
 }

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -252,9 +252,7 @@ export function withSearchParamsPersist(
 
     theAtom.__reatom.computer = (ctx, state) => {
       ctx.spy(searchParamsAtom, (next, prev) => {
-        const currentPath = ctx.spy(urlAtom).pathname
-
-        if (subpath && currentPath.startsWith(subpath() as string)) {
+         
           if (key in next) {
             if (!prev || prev[key] !== next[key]) {
               state = parse(next[key])
@@ -264,7 +262,7 @@ export function withSearchParamsPersist(
               state = initState(ctx)
             }
           }
-        }
+
       })
 
       if (computer) {


### PR DESCRIPTION
#880 

Hello @artalar ,
I tried tackling on this issue, but I'm not sure if I managed to solve it . The current test in the url package 'SearchParamsAtom.lens' couldn't pass . I got the behavior below :  ( by adding subpath: () => '/results' parameter to withSearchParamsPersist options object ) 

![ezgif-2-6e00733331](https://github.com/user-attachments/assets/384dbc32-5716-49db-a832-92b5b7912de0)

As you can see , the subpath '' results '' persists while the '' page '' parameter changes 

As I said , I don't know if I solved the issue partially , but perhaps you can find something of value in the changes I made