### PR TITLE
fix(eslint-plugin): typeError in reatom/unit-naming-rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14906,10 +14906,19 @@
       "name": "@reatom/eslint-plugin",
       "version": "3.7.0",
       "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      },
       "devDependencies": {
         "@types/eslint": "^8.0.0",
         "eslint": "^8.0.0"
       }
+    },
+    "packages/eslint-plugin/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "license": "MIT"
     },
     "packages/esm-import-check": {
       "name": "@reatom-private/esm-import-check",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -53,5 +53,8 @@
   "devDependencies": {
     "@types/eslint": "^8.0.0",
     "eslint": "^8.0.0"
+  },
+  "dependencies": {
+    "@types/estree": "^1.0.6"
   }
 }

--- a/packages/eslint-plugin/src/shared.ts
+++ b/packages/eslint-plugin/src/shared.ts
@@ -3,7 +3,11 @@ import type * as estree from 'estree'
 export const reatomFactoryList = ['atom', 'action', 'reaction'] as const
 export const reatomFactoryPattern = new RegExp(`^(reatom\\w+|${reatomFactoryList.join('|')})$`)
 
-export const patternNames = (pattern: estree.Pattern): estree.Identifier[] => {
+export const patternNames = (pattern: estree.Pattern | null): estree.Identifier[] => {
+  if (!pattern) {
+    return []
+  }
+
   if (pattern.type === 'AssignmentPattern') {
     return patternNames(pattern.left)
   }
@@ -13,8 +17,11 @@ export const patternNames = (pattern: estree.Pattern): estree.Identifier[] => {
   if (pattern.type === 'ArrayPattern') {
     return pattern.elements.flatMap(patternNames)
   }
+
   if (pattern.type === 'ObjectPattern') {
-    return pattern.properties.flatMap((property) => (property.key.type === 'Identifier' ? property.key : []))
+    return pattern.properties.flatMap((property) =>
+      property.type === 'Property' && property.key.type === 'Identifier' ? property.key : [],
+    )
   }
   return []
 }


### PR DESCRIPTION
https://github.com/artalar/reatom/issues/967
- Added estree as a dependency to ensure correct type handling and output in ESLint.
- Fixed existing issues related to type errors that were previously causing linting to fail.