### PR TITLE
test(lens): add reviewed reactive change test

### DIFF
--- a/packages/lens/src/match.test.ts
+++ b/packages/lens/src/match.test.ts
@@ -87,4 +87,21 @@ test('default should checks in the end', () => {
   ;`👍` //?
 })
 
+test('reactive change', () => {
+  const ctx = createTestCtx()
+
+  const boolAtom = atom(true)
+  const compAtom = match(boolAtom)
+    .is(true, () => 'a')
+    .default(() => 'b')
+
+  const track = ctx.subscribeTrack(compAtom)
+
+  assert.equal(track.inputs(), ['a'])
+
+  boolAtom(ctx, false)
+  boolAtom(ctx, true)
+  assert.equal(track.inputs(), ['a', 'b', 'a'])
+})
+
 test.run()

--- a/packages/lens/src/match.test.ts
+++ b/packages/lens/src/match.test.ts
@@ -91,8 +91,8 @@ test('reactive change', () => {
   const ctx = createTestCtx()
 
   const boolAtom = atom(true)
-  const compAtom = match(boolAtom)
-    .is(true, () => 'a')
+  const compAtom = match(true)
+    .is(boolAtom, () => 'a')
     .default(() => 'b')
 
   const track = ctx.subscribeTrack(compAtom)

--- a/packages/lens/src/match.ts
+++ b/packages/lens/src/match.ts
@@ -56,7 +56,7 @@ export function match<T>(
   name = __count('match'),
 ): Match<T> {
   type Case = {
-    clause: (ctx: Ctx, expression: T) => boolean
+    clause: (ctx: CtxSpy, expression: T) => boolean
     statement: {} | Atom | ((ctx: Ctx, expression: T) => any)
   }
   const cases: Array<Case> = []
@@ -70,11 +70,12 @@ export function match<T>(
       : typeof expression === 'function'
       ? (expression as Fn)(ctxSpy)
       : expression
-    const ctx = merge(ctxSpy, { spy: undefined })
+      
+  
     const list = [...cases, _truthy, _falsy, _default].filter(Boolean)
 
     for (const { clause, statement } of list) {
-      if (clause(ctx, value)) {
+      if (clause(ctxSpy, value)) {
         return isAtom(statement)
           ? ctxSpy.spy(statement)
           : typeof statement === 'function'
@@ -89,7 +90,7 @@ export function match<T>(
     is(clause: any, statement: any) {
       cases.push({
         clause: isAtom(clause)
-          ? (ctx, value) => Object.is(value, ctx.get(clause))
+          ? (ctx, value) => Object.is(value, ctx.spy(clause))
           : typeof clause === 'function'
           ? clause
           : (ctx, value) => Object.is(value, clause),


### PR DESCRIPTION
fix #970
Hello @artalar ,

The test wasn't passing because of the usage of  <code>match(true)</code> . The <code>match</code> function was fixed with a  <code>true</code> literal value , meaning that <code>compAtom</code> was non-reactive to the changes of <code>boolAtom</code> . 

In the new test, <code>match(boolAtom)</code> was used instead, making <code>match</code> reactive to changes of <code>boolAtom</code> 