### PR TITLE
fix(async): add test isEverSettled after abort

### DIFF
--- a/packages/async/src/withStatusesAtom.test.ts
+++ b/packages/async/src/withStatusesAtom.test.ts
@@ -9,6 +9,7 @@ import {
   AsyncStatusesFirstPending,
   AsyncStatusesFulfilled,
   AsyncStatusesNeverPending,
+  AsyncStatusesNextAbortedDuringPending,
   AsyncStatusesRejected,
   asyncStatusesInitState,
   withStatusesAtom,
@@ -207,6 +208,30 @@ test('do not reject on abort', async () => {
     isEverPending: true,
     isEverSettled: false,
   } satisfies AsyncStatusesAbortedPending)
+  ;`👍` //?
+})
+
+test('isEverSettled after abort', async () => {
+  const fetchData = reatomAsync(async () => sleep()).pipe(withAbort(), withStatusesAtom())
+  const ctx = createTestCtx()
+
+  expect(ctx.get(fetchData.statusesAtom)).toBe(asyncStatusesInitState)
+  await fetchData(ctx)
+  expect(ctx.get(fetchData.statusesAtom).isFulfilled).toBe(true)
+
+  fetchData(ctx)
+  fetchData(ctx)
+  await null
+  expect(ctx.get(fetchData.statusesAtom)).toEqual({
+    isPending: true,
+    isFulfilled: false,
+    isRejected: false,
+    isSettled: false,
+
+    isFirstPending: false,
+    isEverPending: true,
+    isEverSettled: true,
+  } satisfies AsyncStatusesNextAbortedDuringPending)
   ;`👍` //?
 })
 

--- a/packages/async/src/withStatusesAtom.ts
+++ b/packages/async/src/withStatusesAtom.ts
@@ -36,6 +36,16 @@ export interface AsyncStatusesFirstAborted {
   isEverPending: true
   isEverSettled: false
 }
+export interface AsyncStatusesNextAbortedDuringPending {
+  isPending: true
+  isFulfilled: false
+  isRejected: false
+  isSettled: false
+
+  isFirstPending: false
+  isEverPending: true
+  isEverSettled: true
+}
 
 export interface AsyncStatusesAbortedPending {
   isPending: true


### PR DESCRIPTION
```
 FAIL  src/withStatusesAtom.test.ts > isEverSettled after abort
AssertionError: expected { isPending: true, …(6) } to deeply equal { isPending: true, …(6) }

- Expected
+ Received

  Object {
    "isEverPending": true,
-   "isEverSettled": true,
+   "isEverSettled": false,
    "isFirstPending": false,
    "isFulfilled": false,
    "isPending": true,
    "isRejected": false,
    "isSettled": false,
  }

 ❯ src/withStatusesAtom.test.ts:225:43
    223|   fetchData(ctx)
    224|   await null
    225|   expect(ctx.get(fetchData.statusesAtom)).toEqual({
       |                                           ^
    226|     isPending: true,
    227|     isFulfilled: false,

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

```