### PR TITLE
fix(jsx): props are set as properties

### DIFF
--- a/packages/jsx/src/index.test.tsx
+++ b/packages/jsx/src/index.test.tsx
@@ -871,3 +871,148 @@ test('linked list', () =>
       '<div><!----><span>1</span><!--test--><br><!--test--><!----></div>',
     )
   }))
+
+const expectHtmlElementProperty = <
+  Tag extends keyof JSX.HTMLElementTags,
+  Property extends keyof JSX.HTMLElementTags[Tag],
+  Value extends JSX.HTMLElementTags[Tag][Property],
+  Expected extends Tag extends keyof HTMLElementTagNameMap
+    ? Property extends keyof HTMLElementTagNameMap[Tag]
+      ? HTMLElementTagNameMap[Tag][Property]
+      : never
+    : never,
+>(
+  tag: Tag,
+  prop: Property & string,
+  value: Value,
+  expected: Expected,
+  hasAttr: boolean,
+  getAttr: null | string,
+) => {
+  const element = h(tag, { [prop]: value }) as HTMLElement
+  expect((element as any)[prop]).toBe(expected)
+  expect(element.hasAttribute(prop.toLowerCase())).toBe(hasAttr)
+  expect(element.getAttribute(prop.toLowerCase())).toBe(getAttr)
+}
+
+test('width property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('img', 'width', undefined, 0, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('img', 'width', null, 0, false, null)
+    expectHtmlElementProperty('img', 'width', 1, 1, true, '1')
+    expectHtmlElementProperty('img', 'width', '1', 1, true, '1')
+    expectHtmlElementProperty('img', 'width', -1, 0, true, '-1')
+  }))
+
+test('height property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('img', 'height', undefined, 0, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('img', 'height', null, 0, false, null)
+    expectHtmlElementProperty('img', 'height', 1, 1, true, '1')
+    expectHtmlElementProperty('img', 'height', '1', 1, true, '1')
+    expectHtmlElementProperty('img', 'height', -1, 0, true, '-1')
+  }))
+
+test('download property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('a', 'download', undefined, '', false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('a', 'download', null, '', false, null)
+    // expectHtmlElementProperty('a', 'download', false, '', false, null)
+    // expectHtmlElementProperty('a', 'download', true, '', true, '')
+    expectHtmlElementProperty('a', 'download', 'abc', 'abc', true, 'abc')
+  }))
+
+test('href property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('a', 'href', undefined, '', false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('a', 'href', null, '', false, null)
+    expectHtmlElementProperty('a', 'href', 'https://test.com/', 'https://test.com/', true, 'https://test.com/')
+  }))
+
+test('list property', () =>
+  root.start(async () => {
+    const element = <input list="list"></input>
+    const list = <datalist id="list"></datalist>
+    mount(parent(), <div>{element}{list}</div>)
+
+    expect(element.list).toBe(list)
+    expect(element.hasAttribute('list')).toBe(true)
+    expect(element.getAttribute('list')).toBe('list')
+
+    expectHtmlElementProperty('input', 'list', undefined, null, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('input', 'list', null, null, false, null)
+  }))
+
+test('form property', () =>
+  root.start(async () => {
+    const element = <input form="form"></input>
+    const form = <form id="form"></form>
+    mount(parent(), <div>{element}{form}</div>)
+
+    expect(element.form).toBe(form)
+    expect(element.hasAttribute('form')).toBe(true)
+    expect(element.getAttribute('form')).toBe('form')
+
+    expectHtmlElementProperty('input', 'form', undefined, null, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('input', 'form', null, null, false, null)
+  }))
+
+test('tabIndex property', () =>
+  root.start(async () => {
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'tabIndex', undefined, -1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'tabIndex', null, -1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'tabIndex', 0, 0, true, '0')
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'tabIndex', '0', 0, true, '0')
+  }))
+
+test('rowSpan property', () =>
+  root.start(async () => {
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'rowSpan', undefined, 1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'rowSpan', null, 1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'rowSpan', 0, 0, true, '0')
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'rowSpan', -1, 1, true, '-1')
+  }))
+
+test('colSpan property', () =>
+  root.start(async () => {
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'colSpan', undefined, 1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'colSpan', null, 1, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'colSpan', 1, 1, true, '1')
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('td', 'colSpan', 0, 1, true, '0')
+  }))
+
+test('role property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('div', 'role', undefined, null, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'role', null, null, false, null)
+    expectHtmlElementProperty('div', 'role', 'alert', 'alert', true, 'alert')
+  }))
+
+test('popover property', () =>
+  root.start(async () => {
+    expectHtmlElementProperty('div', 'popover', undefined, null, false, null)
+    // @ts-expect-error TODO fix types
+    expectHtmlElementProperty('div', 'popover', null, null, false, null)
+    expectHtmlElementProperty('div', 'popover', false, null, false, null)
+    expectHtmlElementProperty('div', 'popover', true, 'auto', true, '')
+    expectHtmlElementProperty('div', 'popover', 'auto', 'auto', true, 'auto')
+  }))

--- a/packages/jsx/src/index.test.tsx
+++ b/packages/jsx/src/index.test.tsx
@@ -609,8 +609,8 @@ test('class and className attribute', () =>
     await wrap(sleep())
     expect(ref1.className).toBe('')
     expect(ref2.className).toBe('')
-    expect(ref1.hasAttribute('class')).toBe(false)
-    expect(ref2.hasAttribute('class')).toBe(false)
+    expect(ref1.hasAttribute('class')).toBe(true)
+    expect(ref2.hasAttribute('class')).toBe(true)
   }))
 
 test('ref mount and unmount callbacks order', () =>

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -59,6 +59,25 @@ export let stylesheet = atom<HTMLElement>(null as any, 'jsx.stylesheet').mix(
 )
 let name = ''
 
+/**
+ * @see https://github.com/preactjs/preact/blob/d16a34e275e31afd6738a9f82b5ba2fb9dbf032b/src/diff/props.js#L107
+ * @see https://www.measurethat.net/Benchmarks/Show/7818
+ */
+let propertiesAsAttributes = new Set([
+  'width',
+  'height',
+  'href',
+  'list',
+  'form',
+  /** Default value in browsers is `-1` and an empty string is cast to `0` instead */
+  'tabIndex',
+  'download',
+  'rowSpan',
+  'colSpan',
+  'role',
+  'popover',
+])
+
 let isSkipped = (value: unknown): value is boolean | '' | null | undefined =>
   typeof value === 'boolean' || value === '' || value == null
 
@@ -274,22 +293,34 @@ let set = (dom: DomApis, element: JSX.Element, key: string, val: any) => {
   } else if (key.startsWith('prop:')) {
     // @ts-expect-error
     element[key.slice(5)] = val
+  } else if (
+    !propertiesAsAttributes.has(key)
+    && element instanceof dom.HTMLElement
+    && (key in element || key === 'class')
+  ) {
+    /**
+     * @see https://measurethat.net/Benchmarks/Show/54
+     * @see https://measurethat.net/Benchmarks/Show/31249
+     */
+    if (key === 'class') key = 'className'
+    // @ts-ignore
+    element[key] = val == null ? '' : val
   } else {
     if (key === 'className') key = 'class'
     else if (key.startsWith('attr:')) key = key.slice(5)
 
-    if (val == null || val === false) element.removeAttribute(key)
-    else {
-      val = val === true ? '' : String(val)
-      /**
-       * @see https://measurethat.net/Benchmarks/Show/54
-       * @see https://measurethat.net/Benchmarks/Show/31249
-       */
-      if (key === 'class' && element instanceof dom.HTMLElement) {
-        element.className = val
-      } else {
-        element.setAttribute(key, val)
-      }
+    /**
+     * @note aria- and data- attributes have no boolean representation.
+     * A `false` value is different from the attribute not being
+     * present, so we can't remove it. For non-boolean aria
+     * attributes we could treat false as a removal, but the
+     * amount of exceptions would cost too many bytes. On top of
+     * that other frameworks generally stringify `false`.
+     */
+    if (val == null || (val === false && key[4] !== '-')) {
+      element.removeAttribute(key)
+    } else {
+      element.setAttribute(key, key == 'popover' && val == true ? '' : val)
     }
   }
 }

--- a/packages/jsx/src/jsx.d.ts
+++ b/packages/jsx/src/jsx.d.ts
@@ -790,7 +790,7 @@ export namespace JSX {
   }
   interface AnchorHTMLAttributes<T = HTMLElementTagNameMap['anchor']>
     extends HTMLAttributes<T> {
-    download?: any
+    download?: string
     href?: string
     hreflang?: string
     media?: string
@@ -806,7 +806,7 @@ export namespace JSX {
     extends HTMLAttributes<T> {
     alt?: string
     coords?: string
-    download?: any
+    download?: string
     href?: string
     hreflang?: string
     ping?: string
@@ -2306,9 +2306,7 @@ export namespace JSX {
     section: HTMLAttributes<HTMLElementTagNameMap['section']>
     select: SelectHTMLAttributes<HTMLElementTagNameMap['select']>
     slot: HTMLSlotElementAttributes
-    HTMLElementTagNameMap: HTMLAttributes<
-      HTMLElementTagNameMap['HTMLElementTagNameMap']
-    >
+    small: HTMLAttributes<HTMLElementTagNameMap['small']>
     source: SourceHTMLAttributes<HTMLElementTagNameMap['source']>
     span: HTMLAttributes<HTMLElementTagNameMap['span']>
     strong: HTMLAttributes<HTMLElementTagNameMap['strong']>


### PR DESCRIPTION
https://github.com/artalar/reatom/issues/998

Changes the approach from `attribute first` to `property first`. If there is a property with this name, then we set the value to the property, otherwise we set the value to the attribute. If the property exists, but we want to set the attribute, then `attr:` is added to the property name, for example, `attr:value="abc"`