### PR TITLE
fix(eslint-plugin): false-negative for `name` as prop and invalid derivation for objects inside a named factory

### DIFF
--- a/packages/eslint-plugin/src/rules/unit-naming-rule.test.ts
+++ b/packages/eslint-plugin/src/rules/unit-naming-rule.test.ts
@@ -31,7 +31,10 @@ tester.run('unit-naming-rule', unitNamingRule, {
     },
     { 
       code: `function reatomSome({name}) { const Atoms = { someAtom: atom(0, \`\${name}.Atoms.someAtom\`) } }`
-    },
+    }, 
+    {
+      code: `const someFactory = reatomSome({ name: 'someFactory' })`
+    }
   ],
   invalid: [
     {
@@ -60,6 +63,11 @@ tester.run('unit-naming-rule', unitNamingRule, {
       options: [{ atomPostfix: 'Atom' }],
       errors: [{ message: /name must end with/ }],
       output: `const someAtom = atom(0, 'someAtom')`,
+    },
+    {
+      code: `const someFactory = reatomSome({})`,
+      errors: [{ message: /missing/ }],
+      output: `const someFactory = reatomSome({ name: 'someFactory' })`,
     },
     {
       code: `function reatomSome() { const field = atom(0, 'Some._unrelated'); }`,

--- a/packages/eslint-plugin/src/rules/unit-naming-rule.test.ts
+++ b/packages/eslint-plugin/src/rules/unit-naming-rule.test.ts
@@ -29,6 +29,9 @@ tester.run('unit-naming-rule', unitNamingRule, {
     {
       code: `function reatomSome() { const Atoms = { someAtom: atom(0, 'Some.Atoms.someAtom') } }`,
     },
+    { 
+      code: `function reatomSome({name}) { const Atoms = { someAtom: atom(0, \`\${name}.Atoms.someAtom\`) } }`
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/src/rules/unit-naming-rule.ts
+++ b/packages/eslint-plugin/src/rules/unit-naming-rule.ts
@@ -162,7 +162,7 @@ export const unitNamingRule: Rule.RuleModule = {
             const afterDomain = nameNode.quasis[1]!.value.raw.slice(1)
             const [object, self] = afterDomain.includes('.') ? afterDomain.split('.') : [null, afterDomain]
             const local = self.startsWith('_')
-            const unit = afterDomain.slice(local ? 1 : 0)
+            const unit = afterDomain.slice(local ? 1 : 0).split('.').at(-1)
             parsedName = { domain: { is: 'dynamic', vary: domainVary }, object, local, unit }
           }
         }

--- a/packages/eslint-plugin/src/rules/unit-naming-rule.ts
+++ b/packages/eslint-plugin/src/rules/unit-naming-rule.ts
@@ -133,16 +133,17 @@ export const unitNamingRule: Rule.RuleModule = {
           return
         }
 
-        const replaceNameFix = (fixer: Rule.RuleFixer, local = false) => {
-          const fixedCode = printName({
-            domain: expectedDomain,
-            object: expectedObject,
-            local,
-            unit: expectedUnit.name,
-          })
-
-          return fixer.replaceText(nameNode, nameNode.type === 'Property' ? `name: ${fixedCode}` : fixedCode)
-        }
+        const replaceNameFix = (fixer: Rule.RuleFixer, local = false) => (
+          fixer.replaceText(
+            nameNode, 
+            printName({
+              domain: expectedDomain,
+              object: expectedObject,
+              local,
+              unit: expectedUnit.name,
+            })
+          )
+        )
 
         let parsedName: Name | undefined
         parseName: {


### PR DESCRIPTION
Fixes some issues related to factories:

1) false-negative error if `name` used as a object property
![image](https://github.com/user-attachments/assets/e620c8f2-c9d9-4e3d-9224-66abf04d35d4)

2) incorrect name derivation for an atom inside an object that is nested in a named factory
![image](https://github.com/user-attachments/assets/5a025aa4-56e8-4b51-b5c0-937d0a521143)
