### PR TITLE
feat(form): add centralized fields initialization, add support for array fields, add `withField`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2548,10 +2548,10 @@
         "win32"
       ]
     },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.11.0.tgz",
-      "integrity": "sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==",
+    "node_modules/@surma/rollup-plugin-off-main-thread": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
+      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9385,10 +9385,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "license": "MIT",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9480,15 +9479,7 @@
     },
     "packages/devtools": {
       "name": "@reatom/devtools",
-      "version": "0.13.1",
-      "bundleDependencies": [
-        "@observablehq/inspector",
-        "@reatom/framework",
-        "@reatom/jsx",
-        "@reatom/npm-zod",
-        "jsondiffpatch",
-        "zod"
-      ],
+      "version": "0.11.4",
       "license": "MIT",
       "devDependencies": {
         "@observablehq/inspector": "^5.0.0",
@@ -9593,6 +9584,10 @@
         "@reatom/hooks": "^3.1.0",
         "@reatom/primitives": "^3.1.0",
         "@reatom/utils": "^3.7.0"
+      },
+      "devDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "zod": "^3.24.1"
       }
     },
     "packages/form-web": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2548,36 +2548,11 @@
         "win32"
       ]
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "~8.13.0",
-        "ajv-draft-04": "~1.0.0",
-        "ajv-formats": "~3.0.1",
-        "fs-extra": "~11.3.0",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2594,7 +2569,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2607,7 +2582,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2623,7 +2598,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
+      "extraneous": true,
       "license": "ISC"
     },
     "node_modules/@rushstack/rig-package": {
@@ -2699,6 +2674,13 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
       "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3700,39 +3682,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/alien-signals": {
@@ -5514,31 +5463,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5732,13 +5656,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/graphql": {
       "version": "16.10.0",
@@ -6009,16 +5926,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-lazy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -6371,29 +6278,6 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/jsonparse": {
@@ -9385,9 +9269,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9479,7 +9364,15 @@
     },
     "packages/devtools": {
       "name": "@reatom/devtools",
-      "version": "0.11.4",
+      "version": "0.13.1",
+      "bundleDependencies": [
+        "@observablehq/inspector",
+        "@reatom/framework",
+        "@reatom/jsx",
+        "@reatom/npm-zod",
+        "jsondiffpatch",
+        "zod"
+      ],
       "license": "MIT",
       "devDependencies": {
         "@observablehq/inspector": "^5.0.0",

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -28,21 +28,19 @@ export const passwordField = reatomField('', {
 })
 
 // Create a form with the fields
-export const loginForm = reatomForm(
-  {
-    username: nameField,
-    password: passwordField
+export const loginForm = reatomForm({
+  username: nameField,
+  password: passwordField
+}, {
+  name: 'form',
+  async onSubmit(ctx, state) {
+    //                ^? ParseAtoms<typeof loginForm.fields>
+    const user = await api.login({
+      name: state.username,
+      password: state.password,
+    })
   },
-  {
-    async onSubmit(ctx, state) {
-      //                ^? ParseAtoms<typeof loginForm.fields>
-      const user = await api.login(ctx, {
-        name: state.username,
-        password: state.password,
-      })
-    },
-  }
-)
+})
 ```
 
 ### Form with Schema Validation
@@ -64,6 +62,7 @@ const userForm = reatomForm({
     }
   ])
 }, {
+  name: 'form',
   // Schema validation using zod
   schema: z.object({
     username: z.string().min(3, 'Username must be at least 3 characters'),
@@ -98,7 +97,7 @@ const form = reatomForm({
   age: 25, // Number field
   isActive: true, // Boolean field
   birthDate: new Date(), // Date field
-})
+}, 'form')
 ```
 
 2. **Field Options Object**:
@@ -109,7 +108,7 @@ const form = reatomForm({
   username: { 
     initState: '', 
     validateOnChange: true,
-    validate: (ctx, { state }) => {
+    validate: ({ state }) => {
       if (state.length < 3) throw new Error('Too short')
     }
   },
@@ -117,19 +116,19 @@ const form = reatomForm({
     initState: 25, 
     validateOnBlur: true 
   }
-})
+}, 'form')
 ```
 
 3. **Existing `reatomField` Instances**:
 
 ```ts
-const usernameField = reatomField('', 'usernameField')
+const usernameField = reatomField('', 'usernameField').extend(withLocalStorage())
 const ageField = reatomField(25, 'ageField')
 
 const form = reatomForm({
   username: usernameField,
   age: ageField
-})
+}, 'form')
 ```
 You are free to attach existing fields to the form. However, note that in this case, the fields will not receive naming scoped to the form domain. 
 For better debbuging experience, it is recommended to initialize fields directly within the form's field tree, initializing the name similar to how it is done in factories. 
@@ -141,7 +140,7 @@ import { reatomForm, reatomField } from '@reatom/form'
 const form = reatomForm(name => ({
   username: reatomField('', `${name}.username`),
   password: reatomField('', `${name}.password`),
-}))
+}), 'form')
 ```
 
 4. **Atoms Extended with `withField`**:
@@ -153,8 +152,186 @@ import { withField } from '@reatom/form'
 
 const form = reatomForm(name => ({
   active: reatomBoolean(false, `${name}.active`).pipe(withField())
-}))
+}), 'form')
 ```
+
+## Array Fields
+
+The `fieldArray` function allows you to create dynamic arrays of fields that can be added, removed, and manipulated.
+
+### Array Fields Initialization
+
+There are several ways to initialize array fields:
+
+1. **Simple Array Literals**:
+```ts
+const form = reatomForm({
+  // Empty array field
+  tags: [],
+  
+  // Array with default item as a string field
+  emails: ['default@example.com'],
+  
+  // Array with default item as a string field through options definition
+  phones: [
+    { initState: '123-456-7890', validateOnChange: true }
+  ]
+}, 'form')
+```
+
+2. **Empty Array with Type Information**:
+```ts
+const form = reatomForm({
+  // Empty array with correct type information
+  emails: new Array<string>(),
+  contacts: new Array<{ name: string, phone: string }>()
+}, 'form')
+```
+
+3. **Using fieldArray Function**:
+```ts
+const form = reatomForm({
+  // Empty array field
+  tags: fieldArray<string>([]),
+  
+  // Array with default values
+  emails: fieldArray(['default@example.com']),
+}, 'form')
+```
+
+4. **Complex Array Field Factory**:
+
+If you want to configure the rules for creating fields in an array field, you should define a factory function that describes how each new field in this array field will be created.
+```ts
+const form = reatomForm({
+  // Using initState and create
+  phoneNumbers: fieldArray({
+    initState: [{ number: '123-456-7890', priority: false }],
+    create: (ctx, { number, priority }, name) => ({
+      number: { initState: number, validateOnChange: true },
+      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
+    })
+  }),
+}, 'form')
+```
+
+### Basic Array Field Operations
+Since we use the "field as model" approach and each field is an object, we can achieve maximum type safety by working directly with objects. But the cherry on top is atomization, a principle used by array fields that allows maintaining a high-quality type-safe experience at any level of nesting in your forms.
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+
+const contactForm = reatomForm({
+  name: '',
+  emails: fieldArray(['']) // Simple array of string fields
+}, 'form')
+
+// Add a new email field
+contactForm.fields.emails.create(ctx, '')
+
+// Access the array of email fields
+const emailFields = ctx.get(contactForm.fields.emails.array)
+
+// Remove a specific email field
+contactForm.fields.emails.remove(ctx, emailFields[0])
+
+// Clear all email fields
+contactForm.fields.emails.clear(ctx)
+```
+
+### Complex Array Fields
+You can create more complex array fields with custom structures:
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+import { reatomBoolean } from '@reatom/primitives'
+import { withField } from '@reatom/form'
+
+const contactForm = reatomForm({
+  name: '',
+  phoneNumbers: fieldArray({
+    initState: new Array<{ number: string, priority: boolean }>(),
+    create: (ctx, { number, priority }, name) => ({
+      number,
+      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
+    })
+  })
+}, 'form')
+
+// Add a new phone number
+contactForm.fields.phoneNumbers.create(ctx, { 
+  number: '123-456-7890', 
+  priority: false 
+})
+```
+
+### Nested Array Fields
+
+You can also create nested array structures:
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+
+const userForm = reatomForm({
+  name: '',
+  addresses: fieldArray([
+    {
+      street: '',
+      city: '',
+      tags: fieldArray(['home'])
+    }
+  ])
+}, 'form')
+
+// Access nested fields
+const addresses = ctx.get(userForm.fields.addresses.array)
+const firstAddressTags = ctx.get(addresses[0]?.tags.array)
+```
+
+## Fields sets
+
+Field sets allow you to group related fields together and manage them as a single unit. This is useful for organizing complex forms into logical sections, such as steps in a multi-step form, or for tracking the combined state of multiple fields without creating a full form.
+
+### Creating and Using Field Sets in Multi-step Forms
+
+A common use case for field sets is creating multi-step forms where each step has its own validation and state management:
+
+```ts
+import { reatomForm, reatomFieldSet } from '@reatom/form'
+import { computed } from '@reatom/core'
+
+const checkoutForm = reatomForm({
+  personal: {
+    firstName: '',
+    lastName: '',
+    email: {
+      initState: '',
+      validate: ({ state }) => invariant(state.includes('@'), 'Invalid email format')
+    }
+  },
+  shipping: {
+    address: '',
+    city: '',
+    zipCode: {
+      initState: '',
+      validate: ({ state }) => invariant(/^\d{5}$/.test(state), 'Invalid zip code format')
+    }
+  }
+}, 'checkoutForm')
+
+// Create field sets for each step
+const personalInfoSet = reatomFieldSet(checkoutForm.fields.personal, 'checkoutForm.personalSet')
+const shippingInfoSet = reatomFieldSet(checkoutForm.fields.shipping, 'checkoutForm.shippingSet')
+```
+
+Each field set (`personalInfoSet` and `shippingInfoSet`) provides access to:
+
+- `fieldsState`: The combined state of all fields in the set
+- `validation`: The combined validation status of all fields in the set
+- `focus`: The combined focus status of all fields in the set
+- Other methods like `reset`, `init` and properties as in the forms
+
+Field sets are particularly useful for multi-step forms because they allow you to validate each step independently before allowing the user to proceed to the next step, or for reactive calculations for groups of fields.
 
 ## Form API
 
@@ -200,26 +377,33 @@ Here is the list of all additional properties and methods:
   - `active`: The field is focused.
   - `dirty`: The field's state is not equal to the initial state.
   - `touched`: The field has gained and lost focus at some point.
+  - `in`: Action for handling field focus.
+  - `out`: Action for handling field blur.
 - `validation`: Record atom with all related validation statuses:
   - `error`: The field validation error text, undefined if the field is valid.
   - `meta`: Additional validation metadata.
   - `triggered`: The validation actuality status.
   - `validating`: The field async validation status.
+  - `trigger`: Action to trigger field validation.
+  - `setError`: Action to set an error for the field.
 - `value`: Atom with the "value" data, computed by the `fromState` option.
 - `change`: Action for handling field changes, accepts the "value" parameter and applies it to `toState` option.
-- `focus.in`: Action for handling field focus.
-- `focus.out`: Action for handling field blur.
 - `reset`: Action to reset the state, the value, the validation, and the focus.
-- `validation.trigger`: Action to trigger field validation.
-- `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation.
-- `keepErrorOnChange`: Defines the reset behavior of the validation state on field change.
-- `validateOnChange`: Defines if the validation should be triggered with every field change.
-- `validateOnBlur`: Defines if the validation should be triggered on the field blur.
+- `disabled`: Atom that defines if the field is disabled.
+- `options`: Record atom with all related field options:
+  - `keepErrorDuringValidating`: Value that defines the reset behavior of the validation state during async validation.
+  - `keepErrorOnChange`: Value that defines the reset behavior of the validation state on field change.
+  - `validateOnChange`: Value that defines if the validation should be triggered with every field change.
+  - `validateOnBlur`: Value that defines if the validation should be triggered on the field blur.
 
 By combining these statuses you can derive additional meta information:
 
 - `!touched && active` - the field got focus for the first time
 - `touched && active` - the field got focus again
+
+### Disabled Fields Behavior
+
+When fields are disabled, they no longer automatically trigger their own validation. In field sets, these disabled fields are excluded from the `validation` and `focus` computations, meaning they are not considered in the validation process according to the schema. This ensures that disabled fields do not affect the validation status of the form or field set they belong to.
 
 ### Field Options
 
@@ -230,6 +414,7 @@ By combining these statuses you can derive additional meta information:
 - `toState`: The optional callback to transform the "state" data from the "value" data from the `change` action. By default, it returns the "value" data without any transformations.
 - `validate`: The optional callback to validate the field.
 - `contract`: The optional callback to validate field contract.
+- `disabled`: Defines if the field is disabled by default.
 - `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation (default: `false`).
 - `keepErrorOnChange`: Defines the reset behavior of the validation state on field change (default: `!validateOnChange`).
 - `validateOnBlur`: Defines if the validation should be triggered on the field blur (default: `false`).
@@ -264,137 +449,4 @@ flowchart TB
     keepErrorDuringValidating --> |false| keepErrorDuringValidatingFalse["set {error: undefined, valid: true, validating: true}"]
     promise --> |Fulfilled| valid
     promise --> |Rejected| invalid
-```
-
-## Array Fields
-
-The `fieldArray` function allows you to create dynamic arrays of fields that can be added, removed, and manipulated.
-
-### Array Fields Initialization
-
-There are several ways to initialize array fields:
-
-1. **Simple Array Literals**:
-```ts
-const form = reatomForm({
-  // Empty array field
-  tags: [],
-  
-  // Array with default item as a string field
-  emails: ['default@example.com'],
-  
-  // Array with default item as a string field through options definition
-  phones: [
-    { initState: '123-456-7890', validateOnChange: true }
-  ]
-})
-```
-
-2. **Empty Array with Type Information**:
-```ts
-const form = reatomForm({
-  // Empty array with correct type information
-  emails: new Array<string>(),
-  contacts: new Array<{ name: string, phone: string }>()
-})
-```
-
-3. **Using fieldArray Function**:
-```ts
-const form = reatomForm({
-  // Empty array field
-  tags: fieldArray<string>([]),
-  
-  // Array with default values
-  emails: fieldArray(['default@example.com']),
-})
-```
-
-4. **Complex Array Field Factory**:
-
-If you want to configure the rules for creating fields in an array field, you should define a factory function that describes how each new field in this array field will be created.
-```ts
-const form = reatomForm({
-  // Using initState and create
-  phoneNumbers: fieldArray({
-    initState: [{ number: '123-456-7890', priority: false }],
-    create: (ctx, { number, priority }, name) => ({
-      number: { initState: number, validateOnChange: true },
-      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
-    })
-  }),
-})
-```
-
-### Basic Array Field Operations
-Since we use the "field as model" approach and each field is an object, we can achieve maximum type safety by working directly with objects. But the cherry on top is atomization, a principle used by array fields that allows maintaining a high-quality type-safe experience at any level of nesting in your forms.
-
-```ts
-import { reatomForm, fieldArray } from '@reatom/form'
-
-const contactForm = reatomForm({
-  name: '',
-  emails: fieldArray(['']) // Simple array of string fields
-})
-
-// Add a new email field
-contactForm.fields.emails.create(ctx, '')
-
-// Access the array of email fields
-const emailFields = ctx.get(contactForm.fields.emails.array)
-
-// Remove a specific email field
-contactForm.fields.emails.remove(ctx, emailFields[0])
-
-// Clear all email fields
-contactForm.fields.emails.clear(ctx)
-```
-
-### Complex Array Fields
-You can create more complex array fields with custom structures:
-
-```ts
-import { reatomForm, fieldArray } from '@reatom/form'
-import { reatomBoolean } from '@reatom/primitives'
-import { withField } from '@reatom/form'
-
-const contactForm = reatomForm({
-  name: '',
-  phoneNumbers: fieldArray({
-    initState: new Array<{ number: string, priority: boolean }>(),
-    create: (ctx, { number, priority }, name) => ({
-      number,
-      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
-    })
-  })
-})
-
-// Add a new phone number
-contactForm.fields.phoneNumbers.create(ctx, { 
-  number: '123-456-7890', 
-  priority: false 
-})
-```
-
-### Nested Array Fields
-
-You can also create nested array structures:
-
-```ts
-import { reatomForm, fieldArray } from '@reatom/form'
-
-const userForm = reatomForm({
-  name: '',
-  addresses: fieldArray([
-    {
-      street: '',
-      city: '',
-      tags: fieldArray(['home'])
-    }
-  ])
-})
-
-// Access nested fields
-const addresses = ctx.get(userForm.fields.addresses.array)
-const firstAddressTags = ctx.get(addresses[0].tags.array)
 ```

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -4,7 +4,7 @@ This is a general form library with a simple focus and validation management.
 
 The form API is designed for the best type-safety and flexibility. Instead of setting up the form state with a single object, each field is created separately, giving you the ability to fine-tune each field perfectly. As the field and its meta statuses are stored in atoms, you can easily combine them, define hooks, and effects to describe any logic you need.
 
-The cherry on the cake is dynamic field management. You don't need to use weird string APIs like `form.${index}.property`. Instead, you can simply have a list of atom fields using [atomization](https://www.reatom.dev/recipes/atomization/).
+The cherry on the cake is dynamic field management. You don't need to use weird string APIs like `form.${index}.property`. Instead, you can simply have a list of fields using [atomization](https://www.reatom.dev/recipes/atomization/).
 
 ## Installation
 
@@ -15,90 +15,240 @@ npm i @reatom/form
 ## Usage
 
 ```ts
-import { reatomForm } from '@reatom/form'
+import { reatomForm, reatomField } from '@reatom/form'
 
+// Create fields directly
+export const nameField = reatomField('', 'nameField')
+export const passwordField = reatomField('', {
+  name: 'passwordField',
+  validate(ctx, { state }) {
+    if (state.length < 6)
+      throw new Error('The password should have at least six characters.')
+  },
+})
+
+// Create a form with the fields
 export const loginForm = reatomForm(
   {
-    async onSubmit(ctx) {
+    username: nameField,
+    password: passwordField
+  },
+  {
+    async onSubmit(ctx, state) {
+      //                ^? ParseAtoms<typeof loginForm.fields>
       const user = await api.login(ctx, {
-        name: ctx.get(nameField),
-        password: ctx.get(passwordField),
+        name: state.username,
+        password: state.password,
       })
     },
-  },
-  'loginForm',
-)
-export const nameField = loginForm.reatomField({ initState: '' }, 'nameField')
-export const passwordField = loginForm.reatomField(
-  {
-    initState: '',
-    validate(ctx, { state }) {
-      if (state.length < 6)
-        throw new Error('The password should have at least six characters.')
-    },
-  },
-  'passwordField',
+  }
 )
 ```
 
-<!-- You could find more examples in [reatom/form-web](https://www.reatom.dev/package/form-web/) package. -->
+### Form with Schema Validation
+The `schema` option supports any schema that implements the [Standard Schema interface](https://github.com/standard-schema/standard-schema)
 
-### Form API
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+import { z } from 'zod'
 
-The `loginForm` above has a few fields to track and manage the form.
+// Create a form with schema validation
+const userForm = reatomForm({
+  username: '',
+  email: '',
+  addresses: fieldArray([
+    {
+      street: '',
+      city: '',
+      zipCode: ''
+    }
+  ])
+}, {
+  // Schema validation using zod
+  schema: z.object({
+    username: z.string().min(3, 'Username must be at least 3 characters'),
+    email: z.string().email('Invalid email format'),
+    addresses: z.array(
+      z.object({
+        street: z.string().min(1, 'Street is required'),
+        city: z.string().min(1, 'City is required'),
+        zipCode: z.string().regex(/^\d{5}$/, 'Invalid zip code format')
+      })
+    )
+  }),
+  async onSubmit(ctx, state) {
+    //                ^? z.infer<typeof schema>
+  }
+})
+```
 
-- `fieldsListAtom`: Atom with a list of fields created by this form's `reatomField` method.
-- `focusAtom`: Atom with focus state of the form, computed from all the fields in `fieldsListAtom`
-- `onSubmit`: Submit async handler. It checks the validation of all the fields in `fieldsListAtom`, calls the form's `validate` options handler, and then the `onSubmit` options handler. Check the additional options properties of async action: https://www.reatom.dev/package/async/.
-- `reatomField`: This method is similar to the `reatomField` method, but it includes bindings to `fieldsListAtom`. It also provides an additional `remove` method to clean itself up from `fieldsListAtom`.
+## Field Initialization
+
+When creating a form, you can initialize fields in several ways:
+
+### Field Initialization Options
+
+1. **Primitive Values**:
+
+By passing a primitive value, you implicitly initialize a reatomField with that value as its default.
+This way is suitable when no individual options are needed for the field.
+```ts
+const form = reatomForm({
+  username: '', // String field
+  age: 25, // Number field
+  isActive: true, // Boolean field
+  birthDate: new Date(), // Date field
+})
+```
+
+2. **Field Options Object**:
+
+By passing an object with `initState` property, you can initialize a reatomField with a value as its default, and pass additional options for the field.
+```ts
+const form = reatomForm({
+  username: { 
+    initState: '', 
+    validateOnChange: true,
+    validate: (ctx, { state }) => {
+      if (state.length < 3) throw new Error('Too short')
+    }
+  },
+  age: { 
+    initState: 25, 
+    validateOnBlur: true 
+  }
+})
+```
+
+3. **Existing `reatomField` Instances**:
+
+```ts
+const usernameField = reatomField('', 'usernameField')
+const ageField = reatomField(25, 'ageField')
+
+const form = reatomForm({
+  username: usernameField,
+  age: ageField
+})
+```
+You are free to attach existing fields to the form. However, note that in this case, the fields will not receive naming scoped to the form domain. 
+For better debbuging experience, it is recommended to initialize fields directly within the form's field tree, initializing the name similar to how it is done in factories. 
+For this purpose, the form's initState accepts a callback with the `name` parameter.
+
+```ts
+import { reatomForm, reatomField } from '@reatom/form'
+
+const form = reatomForm(name => ({
+  username: reatomField('', `${name}.username`),
+  password: reatomField('', `${name}.password`),
+}))
+```
+
+4. **Atoms Extended with `withField`**:
+
+Also, you can extend existing smart atoms with the field functionality. In this case, the atom itself will become the state of the field, and any methods that mutate the extended atom will change the state of this field.
+```ts
+import { reatomBoolean } from '@reatom/primitives'
+import { withField } from '@reatom/form'
+
+const form = reatomForm(name => ({
+  active: reatomBoolean(false, `${name}.active`).pipe(withField())
+}))
+```
+
+## Form API
+
+The form created with `reatomForm` has the following properties:
+
+- `fields`: Object containing all the fields created for this form.
+- `fieldsState`: Atom with the state of the form, computed from all the fields.
+- `focus`: Atom with focus state of the form, computed from all the fields.
+- `init`: Action to initialize the form with a partial state.
 - `reset`: Action to reset the state, the value, the validation, and the focus states.
-- `validationAtom`: Atom with validation state of the form, computed from all the fields in `fieldsListAtom`
-- `formValidationAtom`: Atom with validation statuses around form `validate` options handler.
+- `submit`: Submit async handler. It checks the validation of all the fields, calls the form's `validate` options handler, and then the `onSubmit` options handler.
+- `submitted`: Atom indicating if the form has been submitted.
+- `validation`: Atom with validation state of the form, computed from all the fields.
 
-### Form options
+### Form Options
 
-- `onSubmit`: The callback to process valid form data
-- `onSubmitError`: The callback to handle validation errors on the attempt to submit
+- `name`: The name of the form (optional, auto-generated if not provided).
+- `onSubmit`: The callback to process valid form data.
+- `resetOnSubmit`: Should reset the state after successful submit? (default: `true`).
 - `validate`: The callback to validate form fields.
+- `schema`: A schema for validation (supports StandardSchemaV1 specification, like Zod, Valibot, etc).
+- `validateOnChange`: Defines if validation should be triggered with every field change by default for all fields (default: `false`).
+- `validateOnBlur`: Defines if validation should be triggered on field blur by default for all fields (default: `false`).
+- `keepErrorDuringValidating`: Defines the default reset behavior of the validation state during async validation for all fields (default: `false`).
+- `keepErrorOnChange`: Defines the default reset behavior of the validation state on field change for all fields (default: `!validateOnChange`).
 
-### Form validation behavior
+### Form Validation Behavior
 
-The `form.onSubmit` call triggers the validation process of all related fields (which are stored in `fieldsListAtom`). After that, the validation function from the options will be called. If there are no validation errors, the `onSubmit` callback in the options is called. If the validation fails, the `onSubmitError` callback is called.
+The `form.submit` call triggers the validation process of all related fields. If a schema is provided, it will be used to validate the form state. After that, the validation function from the options will be called. If there are no validation errors, the `onSubmit` callback in the options is called.
 
-You can track the submitting process in progress using `form.onSubmit.pendingAtom`.
+You can track the submitting process in progress using `form.submit.statusesAtom`.
 
-### Field API
+## Field API
 
-A field (`FieldAtom` type) itself is an atom, and you can change it like a regular atom by calling it with the new value or reducer callback.
+A field created with `reatomField` is an atom, and you can change it like a regular atom by calling it with the new value or reducer callback.
 
-The atom stores "state" data. However, there is an additional `valueAtom` that stores "value" data, which could be a different kind of state related to the end UI. For example, for a select field, you want to store the `string` "state" and `{ value: string, label: string }` "value," which will be used in the "Select" UI component.
+The field stores "state" data. However, there is an additional `value` atom that stores "value" data, which could be a different kind of state related to the UI. For example, for a select field, you might want to store the `string` "state" and `{ value: string, label: string }` "value," which will be used in the "Select" UI component.
 
-Here is the list of all additional methods.
+Here is the list of all additional properties and methods:
 
-- `initState`: The initial state of the atom, readonly.
-- `focusAtom`: Atom of an object with all related focus statuses. This atom has additional `reset` action. State properties:
+- `initState`: The initial state of the field.
+- `focus`: Record atom with all related focus statuses:
   - `active`: The field is focused.
-  - `dirty`: The field's state is not equal to the initial state. You can manage this using the [`isDirty` option](#field-options).
+  - `dirty`: The field's state is not equal to the initial state.
   - `touched`: The field has gained and lost focus at some point.
-- `validationAtom`: Atom of an object with all related validation statuses. This atom has additional `reset` action. State properties:
-  - `error`: The field's validation error text, undefined if the field is valid.
-  - `valid`: The validation status of the field. Indicates that the validation is up to date. A `true` value does not mean that the state is correct, it means that validation has taken place. Any change to the state of the field will drop this status to `false` (it could synchronously return to `true` if validation is triggered).
-  - `validating`: The field's async validation status.
-- `valueAtom`: Atom with the "value" data, computed by the [`fromState` option](#field-options).
-- `blur`: Action for handling field blur.
-- `change`: Action for handling field changes, accepts the "value" parameter and applies it to [`toState` option](#field-options).
-- `focus`: Action for handling field focus.
+- `validation`: Record atom with all related validation statuses:
+  - `error`: The field validation error text, undefined if the field is valid.
+  - `meta`: Additional validation metadata.
+  - `triggered`: The validation actuality status.
+  - `validating`: The field async validation status.
+- `value`: Atom with the "value" data, computed by the `fromState` option.
+- `change`: Action for handling field changes, accepts the "value" parameter and applies it to `toState` option.
+- `focus.in`: Action for handling field focus.
+- `focus.out`: Action for handling field blur.
 - `reset`: Action to reset the state, the value, the validation, and the focus.
-- `validate`: Action to trigger field validation.
+- `validation.trigger`: Action to trigger field validation.
+- `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation.
+- `keepErrorOnChange`: Defines the reset behavior of the validation state on field change.
+- `validateOnChange`: Defines if the validation should be triggered with every field change.
+- `validateOnBlur`: Defines if the validation should be triggered on the field blur.
 
-By combining this statuses you can know a different meta info too.
+By combining these statuses you can derive additional meta information:
 
-- `!touched && active` - the field get focus first time
-- `touched && active` - the field get focus another time
+- `!touched && active` - the field got focus for the first time
+- `touched && active` - the field got focus again
 
-### Field validation behavior
+### Field Options
 
-You can set a validation function and manage validation triggers using [the options](#field-options). The flow looks like this.
+- `name`: The name of the field (optional, auto-generated if not provided).
+- `filter`: The optional callback to filter "value" changes (from the 'change' action). It should return 'false' to skip the update. By default, it always returns `true`.
+- `fromState`: The optional callback to compute the "value" data from the "state" data. By default, it returns the "state" data without any transformations.
+- `isDirty`: The optional callback used to determine whether the "value" has changed. Accepts context, the new value and the old value. By default, it utilizes `isDeepEqual` from reatom/utils.
+- `toState`: The optional callback to transform the "state" data from the "value" data from the `change` action. By default, it returns the "value" data without any transformations.
+- `validate`: The optional callback to validate the field.
+- `contract`: The optional callback to validate field contract.
+- `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation (default: `false`).
+- `keepErrorOnChange`: Defines the reset behavior of the validation state on field change (default: `!validateOnChange`).
+- `validateOnBlur`: Defines if the validation should be triggered on the field blur (default: `false`).
+- `validateOnChange`: Defines if the validation should be triggered with every field change (default: `false`).
+
+### Field Validation Behavior
+
+You can set a validation function and manage validation triggers using the options. The validation flow works as follows:
+
+1. When validation is triggered, the system checks if a validation function exists
+2. If no validation function exists, the field is marked as valid
+3. If a validation function exists, it is executed
+4. If the validator throws an error, the field is marked as invalid with the error message
+5. If the validator returns a promise (async validation):
+   - The field is marked as validating
+   - If `keepErrorDuringValidating` is true, the previous error is preserved during validation
+   - If `keepErrorDuringValidating` is false, the error is cleared during validation
+   - When the promise resolves, the field is marked as valid
+   - When the promise rejects, the field is marked as invalid with the error message
 
 ```mermaid
 flowchart TB
@@ -116,14 +266,135 @@ flowchart TB
     promise --> |Rejected| invalid
 ```
 
-### Field options
+## Array Fields
 
-- `initState`: The initial state of the atom, which is the only required option.
-- `filter`: The optional callback to filter "value" changes (from the 'change' action). It should return 'false' to skip the update. By default, it always returns `false`.
-- `fromState`: The optional callback to compute the "value" data from the "state" data. By default, it returns the "state" data without any transformations.
-- `isDirty`: The optional callback used to determine whether the "value" has changed. Accepts context, the new value and the old value. By default, it utilizes `isDeepEqual` from reatom/utils.
-- `toState`: The optional callback to transform the "state" data from the "value" data from the `change` action. By default, it returns the "value" data without any transformations.
-- `validate`: The optional callback to validate the field.
-- `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation. It is `false` by default.
-- `validateOnBlur`: Defines if the validation should be triggered on the field blur. `true` by default
-- `validateOnChange`: Defines if the validation should be triggered with every field change. `!validateOnBlur` by default
+The `fieldArray` function allows you to create dynamic arrays of fields that can be added, removed, and manipulated.
+
+### Array Fields Initialization
+
+There are several ways to initialize array fields:
+
+1. **Simple Array Literals**:
+```ts
+const form = reatomForm({
+  // Empty array field
+  tags: [],
+  
+  // Array with default item as a string field
+  emails: ['default@example.com'],
+  
+  // Array with default item as a string field through options definition
+  phones: [
+    { initState: '123-456-7890', validateOnChange: true }
+  ]
+})
+```
+
+2. **Empty Array with Type Information**:
+```ts
+const form = reatomForm({
+  // Empty array with correct type information
+  emails: new Array<string>(),
+  contacts: new Array<{ name: string, phone: string }>()
+})
+```
+
+3. **Using fieldArray Function**:
+```ts
+const form = reatomForm({
+  // Empty array field
+  tags: fieldArray<string>([]),
+  
+  // Array with default values
+  emails: fieldArray(['default@example.com']),
+})
+```
+
+4. **Complex Array Field Factory**:
+
+If you want to configure the rules for creating fields in an array field, you should define a factory function that describes how each new field in this array field will be created.
+```ts
+const form = reatomForm({
+  // Using initState and create
+  phoneNumbers: fieldArray({
+    initState: [{ number: '123-456-7890', priority: false }],
+    create: (ctx, { number, priority }, name) => ({
+      number: { initState: number, validateOnChange: true },
+      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
+    })
+  }),
+})
+```
+
+### Basic Array Field Operations
+Since we use the "field as model" approach and each field is an object, we can achieve maximum type safety by working directly with objects. But the cherry on top is atomization, a principle used by array fields that allows maintaining a high-quality type-safe experience at any level of nesting in your forms.
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+
+const contactForm = reatomForm({
+  name: '',
+  emails: fieldArray(['']) // Simple array of string fields
+})
+
+// Add a new email field
+contactForm.fields.emails.create(ctx, '')
+
+// Access the array of email fields
+const emailFields = ctx.get(contactForm.fields.emails.array)
+
+// Remove a specific email field
+contactForm.fields.emails.remove(ctx, emailFields[0])
+
+// Clear all email fields
+contactForm.fields.emails.clear(ctx)
+```
+
+### Complex Array Fields
+You can create more complex array fields with custom structures:
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+import { reatomBoolean } from '@reatom/primitives'
+import { withField } from '@reatom/form'
+
+const contactForm = reatomForm({
+  name: '',
+  phoneNumbers: fieldArray({
+    initState: new Array<{ number: string, priority: boolean }>(),
+    create: (ctx, { number, priority }, name) => ({
+      number,
+      priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
+    })
+  })
+})
+
+// Add a new phone number
+contactForm.fields.phoneNumbers.create(ctx, { 
+  number: '123-456-7890', 
+  priority: false 
+})
+```
+
+### Nested Array Fields
+
+You can also create nested array structures:
+
+```ts
+import { reatomForm, fieldArray } from '@reatom/form'
+
+const userForm = reatomForm({
+  name: '',
+  addresses: fieldArray([
+    {
+      street: '',
+      city: '',
+      tags: fieldArray(['home'])
+    }
+  ])
+})
+
+// Access nested fields
+const addresses = ctx.get(userForm.fields.addresses.array)
+const firstAddressTags = ctx.get(addresses[0].tags.array)
+```

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -216,7 +216,17 @@ const form = reatomForm({
 ```
 
 ### Basic Array Field Operations
-Since we use the "field as model" approach and each field is an object, we can achieve maximum type safety by working directly with objects. But the cherry on top is atomization, a principle used by array fields that allows maintaining a high-quality type-safe experience at any level of nesting in your forms.
+Since `fieldArray` is syntactic sugar over `reatomLinkedList`, it provides several methods to manipulate the array of fields:
+
+- `create(value)`: Adds a new field with the given value to the end of the array
+- `remove(field)`: Removes a specific field from the array
+- `clear()`: Removes all fields from the array
+- `array()`: Returns an array of all fields, which you should use to iterate over the fields
+- `swap(field1, field2)`: Swaps the positions of two fields in the array
+- `move(field, targetField)`: Moves a field to a position after the target field (use null to move to the beginning)
+- `find(predicate)`: Finds a field in the array that matches the predicate function
+
+When rendering field arrays in UI components, you should always use the `.array()` method to iterate over the fields.
 
 ```ts
 import { reatomForm, fieldArray } from '@reatom/form'
@@ -232,6 +242,12 @@ contactForm.fields.emails.create(ctx, '')
 // Access the array of email fields
 const emailFields = ctx.get(contactForm.fields.emails.array)
 
+// Iterate over the fields to render them
+// In React, this would look like:
+// {emailFields.map((emailField) => (
+//   <EmailFieldComponent key={emailField.name} field={emailField} />
+// ))}
+
 // Remove a specific email field
 contactForm.fields.emails.remove(ctx, emailFields[0])
 
@@ -239,13 +255,14 @@ contactForm.fields.emails.remove(ctx, emailFields[0])
 contactForm.fields.emails.clear(ctx)
 ```
 
+Since we use the "field as model" approach and each field is an object, we can achieve maximum type safety by working directly with objects. But the cherry on top is atomization, a principle used by array fields that allows maintaining a high-quality type-safe experience at any level of nesting in your forms.
+
 ### Complex Array Fields
 You can create more complex array fields with custom structures:
 
 ```ts
-import { reatomForm, fieldArray } from '@reatom/form'
+import { reatomForm, fieldArray, withField } from '@reatom/form'
 import { reatomBoolean } from '@reatom/primitives'
-import { withField } from '@reatom/form'
 
 const contactForm = reatomForm({
   name: '',
@@ -298,7 +315,6 @@ A common use case for field sets is creating multi-step forms where each step ha
 
 ```ts
 import { reatomForm, reatomFieldSet } from '@reatom/form'
-import { computed } from '@reatom/core'
 
 const checkoutForm = reatomForm({
   personal: {
@@ -320,8 +336,8 @@ const checkoutForm = reatomForm({
 }, 'checkoutForm')
 
 // Create field sets for each step
-const personalInfoSet = reatomFieldSet(checkoutForm.fields.personal, 'checkoutForm.personalSet')
-const shippingInfoSet = reatomFieldSet(checkoutForm.fields.shipping, 'checkoutForm.shippingSet')
+const personalSet = reatomFieldSet(checkoutForm.fields.personal, 'checkoutForm.personalSet')
+const shippingSet = reatomFieldSet(checkoutForm.fields.shipping, 'checkoutForm.shippingSet')
 ```
 
 Each field set (`personalInfoSet` and `shippingInfoSet`) provides access to:
@@ -332,6 +348,133 @@ Each field set (`personalInfoSet` and `shippingInfoSet`) provides access to:
 - Other methods like `reset`, `init` and properties as in the forms
 
 Field sets are particularly useful for multi-step forms because they allow you to validate each step independently before allowing the user to proceed to the next step, or for reactive calculations for groups of fields.
+
+## Recipes
+By composing form and reatom primitives, you can solve long-standing problems in forms as effectively as other libraries do through configuration.
+
+### Async default values
+
+This recipe shows how to load form values from an API. It creates an async resource that fetches data and resets the form with the retrieved values when the request completes. The `pendingAtom` atom can be used to show a loading state.
+
+```ts
+import { reatomForm } from '@reatom/form'
+import { reatomResource, withDataAtom } from '@reatom/async'
+
+const profileForm = reatomForm({
+  username: '',
+  address: ''
+}, 'profileForm')
+
+const fetchFormValues = reatomResource(
+  async (ctx) => {
+    const response = await ctx.schedule(() => fetch('/api/profile'));
+    return ctx.schedule(() => response.json());
+  },
+  'fetchFormValues'
+).pipe(
+  withDataAtom(null)
+)
+
+fetchFormValues.onFulfill.onCall((ctx, defaultValues) => {
+  if(defaultValues)
+    profileForm.reset(ctx, defaultValues)
+})
+
+fetchFormValues.pendingAtom // Use this atom to show loading state
+```
+
+### Async validation debounce
+
+This recipe implements debounced validation for a field. Thanks to reatom's concurrency mechanism, each new validation call automatically cancels the previous one. The field waits 300ms before making an API request to check if a username is already taken.
+
+```ts
+import { reatomField } from '@reatom/form'
+import { sleep } from '@reatom/framework'
+
+const usernameField = reatomField('', {
+  validate: async (ctx, { value }) => {
+    await ctx.schedule(() => sleep(300));
+    const response = await ctx.schedule(() => fetch(`/api/usernames?username=${state}`, ctx.controller));
+    const { taken } = await ctx.schedule(() => response.json());
+    invariant(!taken, 'This username already taken');
+  }
+}, 'usernameField')
+```
+
+The `ctx.controller` provides an AbortController that automatically cancels previous fetch requests when a new validation is triggered, preventing race conditions and unnecessary network requests.
+
+### Dependent validation
+
+There are two approaches to implement validation that depends on other fields.
+
+The first approach uses field-level validation. The `confirmPassword` field directly accesses the value of the `password` field to perform the comparison:
+
+```ts
+import { reatomForm, reatomField } from '@reatom/form'
+
+const loginForm = reatomForm(name => ({
+  username: reatomField('', `${name}.username`),
+  password: reatomField('', `${name}.password`),
+  confirmPassword: reatomField('', {
+    name: `${name}.confirmPassword`,
+    validate: (ctx, { value }) => {
+      if (ctx.get(loginForm.fields.password.value) != value)
+        throw new Error('Passwords do not match')
+    }
+  })
+}), 'loginForm')
+```
+
+The second approach uses schema-level validation with Zod. This centralizes validation logic in the schema and uses the `refine` method to add a custom validation rule:
+
+```ts
+import { reatomForm, reatomField } from '@reatom/form'
+import { z } from 'zod'
+
+const schema = z.object({
+  username: z.string(),
+  password: z.string(),
+  confirmPassword: z.string(),
+}).refine((values) => values.password === values.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+});
+
+const loginForm = reatomForm(name => ({
+  username: reatomField('', `${name}.username`),
+  password: reatomField('', `${name}.password`),
+  confirmPassword: reatomField('', `${name}.confirmPassword`)
+}), {
+  name: 'loginForm',
+  schema
+})
+```
+
+### Autofocus on error
+
+This recipe demonstrates how to automatically focus on the first field with a validation error after a form submission fails. This improves user experience by directing their attention to the field that needs correction.
+
+Each field has an `elementRef` property that can be used to store a reference to the DOM element associated with the field. The `elementRef` interface matches the `HTMLElement` interface, allowing you to call standard DOM methods like `focus()`.
+
+```ts
+const form = reatomForm({
+  email: '',
+  age: 12
+}, {
+  schema: z.object({
+    email: z.string().email(),
+    age: z.number().min(18),
+  })
+})
+
+form.submit.onReject.onCall((ctx) => {
+  const errorField = ctx.get(form.fieldsList).find(field => !!ctx.get(field.validation).error);
+  if(errorField)
+    ctx.get(errorField.elementRef)?.focus();
+})
+```
+
+You can extend the `elementRef` type using interface augmentation if you need to store additional data or custom properties. This is particularly useful when working with custom input components that might have their own API beyond the standard HTMLElement interface.
 
 ## Form API
 
@@ -390,6 +533,7 @@ Here is the list of all additional properties and methods:
 - `change`: Action for handling field changes, accepts the "value" parameter and applies it to `toState` option.
 - `reset`: Action to reset the state, the value, the validation, and the focus.
 - `disabled`: Atom that defines if the field is disabled.
+- `elementRef`: Atom with an element reference. Should be synchronized.
 - `options`: Record atom with all related field options:
   - `keepErrorDuringValidating`: Value that defines the reset behavior of the validation state during async validation.
   - `keepErrorOnChange`: Value that defines the reset behavior of the validation state on field change.
@@ -415,6 +559,7 @@ When fields are disabled, they no longer automatically trigger their own validat
 - `validate`: The optional callback to validate the field.
 - `contract`: The optional callback to validate field contract.
 - `disabled`: Defines if the field is disabled by default.
+- `elementRef`: Defines a default element reference accosiated with the field.
 - `keepErrorDuringValidating`: Defines the reset behavior of the validation state during async validation (default: `false`).
 - `keepErrorOnChange`: Defines the reset behavior of the validation state on field change (default: `!validateOnChange`).
 - `validateOnBlur`: Defines if the validation should be triggered on the field blur (default: `false`).

--- a/packages/form/index.html
+++ b/packages/form/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/sandbox/index.tsx"></script>
+  </body>
+</html>

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -39,5 +39,12 @@
     "url": "https://github.com/artalar/reatom/issues"
   },
   "homepage": "https://www.reatom.dev/package/form",
-  "files": ["/build"]
+  "files": [
+    "/build",
+    "/package.json"
+  ],
+  "devDependencies": {
+    "@standard-schema/spec": "^1.0.0",
+    "zod": "^3.24.1"
+  }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -30,6 +30,16 @@
     "@reatom/utils": "^3.7.0"
   },
   "author": "artalar",
+  "maintainers": [
+    {
+      "name": "artalar",
+      "url": "https://github.com/artalar"
+    },
+    {
+      "name": "Xelson",
+      "url": "https://github.com/xelson"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -1,0 +1,264 @@
+import { AtomState, createCtx } from "@reatom/core";
+import { connectLogger } from "@reatom/logger"
+import { reatomContext, useAction, useAtom } from "@reatom/npm-react"
+import { FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
+import { LinkedListAtom, LinkedListLikeAtom, reatomBoolean } from "@reatom/primitives";
+import { PropsWithChildren } from 'react';
+import { createRoot } from "react-dom/client";
+import { useFormField } from "./use-form-field";
+
+const ctx = createCtx();
+connectLogger(ctx);
+
+function App() {
+	return (
+		<reatomContext.Provider value={ctx}>
+			<Form />
+		</reatomContext.Provider>
+	)
+}
+
+const root = createRoot(document.getElementById('root')!)
+root.render(<App />)
+
+const form = reatomForm(fieldArray => ({
+	username: 'vlad',
+	addresses: [
+		{
+			country: 'my country',
+			street: 'my street',
+			city: 'my city',
+			tags: ['defaultTag', 'defaultTag2'],
+			phoneNumbers: fieldArray({
+				initState: Array<{ number: string, priority: boolean }>(),
+				create: (ctx, { number, priority }) => ({
+					number,
+					priority: reatomBoolean(priority).pipe(withField(priority))
+				})
+			})
+		}
+	],
+}));
+
+const vStack = { display: 'flex', flexDirection: 'column', gap: '1rem' } as const;
+
+function Form() {
+	const submit = useAction(form.submit);
+	const usernameField = useFormField(form.fields.username);
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				gap: '6rem',
+				justifyContent: 'center',
+				width: '100%'
+			}}
+		>
+			<form
+				onSubmit={e => { e.preventDefault(); submit() }}
+				style={{ ...vStack, gap: '0.5rem', width: '100%', maxWidth: '20rem' }}
+			>
+				<input {...usernameField.getInputProps()} />
+
+				<AddressesField />
+			</form>
+
+			<FieldsState />
+		</div>
+	);
+}
+
+function AddressesField() {
+	const [fieldArray] = useAtom(form.fields.addresses.array);
+	const createField = useAction(form.fields.addresses.create);
+	const removeField = useAction(form.fields.addresses.remove);
+
+	const appendField = () => {
+		createField({
+			city: '',
+			country: '',
+			street: '',
+			phoneNumbers: [],
+			tags: []
+		})
+	}
+
+	const removeLatestField = () => {
+		const field = fieldArray.at(-1);
+		if (field)
+			removeField(field);
+	}
+
+	return (
+		<div style={vStack}>
+			{fieldArray.map((field, index) => (
+				<AddressField
+					key={index}
+					model={field}
+				/>
+			))}
+
+			<button type='button' onClick={appendField}>add new</button>
+			<button type='button' onClick={removeLatestField}>remove latest</button>
+		</div>
+	)
+}
+
+type ArrayFieldTypeOf<T> = T extends LinkedListLikeAtom ? AtomState<T['array']>[number] : never
+
+type AddressFieldType = ArrayFieldTypeOf<typeof form.fields.addresses>;
+
+function AddressField({ model }: { model: AddressFieldType }) {
+	const countryField = useFormField(model.country);
+	const streetField = useFormField(model.street);
+	const cityField = useFormField(model.city);
+
+	return (
+		<div style={{ ...vStack, gap: '0.5rem', border: '1px solid black', padding: '0.5rem' }}>
+			<label>
+				Country <input {...countryField.getInputProps()} />
+			</label>
+
+			<label>
+				Street <input {...streetField.getInputProps()} />
+			</label>
+
+			<label>
+				City <input {...cityField.getInputProps()} />
+			</label>
+
+			<TagsField model={model.tags} />
+			<PhoneNumbersField model={model.phoneNumbers} />
+		</div>
+	)
+}
+
+function TagsField({ model }: { model: FormFieldArrayAtom<string, string> }) {
+	const [fieldArray] = useAtom(model.array);
+	const createField = useAction(model.create);
+	const removeField = useAction(model.remove);
+
+	return (
+		<div style={{ display: 'flex', alignItems: 'start', gap: '0.5rem', flexWrap: 'wrap' }}>
+			Tags
+			{fieldArray.map((field, index) => (
+				<TagField
+					key={field.__reatom.name}
+					model={field}
+				>
+					<button type='button' onClick={() => removeField(field)}>-</button>
+				</TagField>
+			))}
+			{!!fieldArray.length && (
+				<div style={{ height: '1.25rem', borderRight: '1px solid black' }} />
+			)}
+			<button type='button' onClick={() => createField('')}>+</button>
+		</div>
+	)
+}
+
+function TagField({ model, children }: PropsWithChildren<{ model: FieldAtom<string> }>) {
+	const field = useFormField(model);
+
+	return (
+		<div
+			style={{ display: 'flex', gap: '0.25rem' }}
+		>
+			<input {...field.getInputProps()} style={{ maxWidth: '4rem' }} />
+			{children}
+		</div>
+	)
+}
+
+function PhoneNumbersField({ model }: { model: AddressFieldType['phoneNumbers'] }) {
+	const [fieldArray] = useAtom(model.array);
+	const createField = useAction(model.create);
+	const removeField = useAction(model.remove);
+
+	return (
+		<div style={{ ...vStack, gap: '0.5rem', border: '1px solid black', padding: '0.5rem' }}>
+			<label>Phone numbers</label>
+
+			{fieldArray.map((field, index) => (
+				<PhoneNumberField
+					key={index}
+					model={field}
+				>
+					<button type='button' onClick={() => removeField(field)}>-</button>
+				</PhoneNumberField>
+			))}
+
+			<button type='button' onClick={() => createField({ number: '', priority: false })}>
+				new phone number
+			</button>
+		</div>
+	)
+}
+
+type PhoneNumberFieldType = ArrayFieldTypeOf<AddressFieldType['phoneNumbers']>
+
+function PhoneNumberField({ model, children }: PropsWithChildren<{ model: PhoneNumberFieldType }>) {
+	const numberField = useFormField(model.number);
+	const priorityField = useFormField(model.priority, 'checkbox');
+
+	return (
+		<div
+			style={{ display: 'flex', gap: '0.25rem' }}
+		>
+			<input {...numberField.getInputProps()} />
+
+			<label>
+				priority
+				<input type='checkbox' {...priorityField.getInputProps()} />
+			</label>
+			{children}
+		</div>
+	)
+}
+
+function FieldsState() {
+	const [fieldsState] = useAtom(form.fieldsState);
+	const reset = useAction(form.reset);
+
+	const resetToEmptyState = () => {
+		reset({ addresses: [], username: '' });
+	}
+
+	const resetToArbitraryState = () => {
+		reset({
+			username: 'foo',
+			addresses: [
+				{
+					city: 'first city',
+					street: 'this street',
+					country: 'this country',
+					tags: [],
+					phoneNumbers: [
+						{ number: '123', priority: true }
+					]
+				},
+				{
+					city: 'second city',
+					street: 'second street',
+					country: 'second country',
+					tags: [],
+					phoneNumbers: [
+						{ number: '356', priority: true }
+					]
+				}
+			]
+		});
+	}
+
+	return (
+		<div style={vStack}>
+			<pre>
+				{JSON.stringify(fieldsState, undefined, 4)}
+			</pre>
+
+			<button onClick={resetToEmptyState}>reset to empty state</button>
+			<button onClick={resetToArbitraryState}>reset to arbitrary state</button>
+		</div>
+	)
+}

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -1,7 +1,7 @@
 import { AtomState, createCtx } from "@reatom/core";
 import { connectLogger } from "@reatom/logger"
 import { reatomContext, useAction, useAtom } from "@reatom/npm-react"
-import { FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
+import { fieldArray, FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
 import { LinkedListLikeAtom, reatomBoolean } from "@reatom/primitives";
 import { PropsWithChildren } from 'react';
 import { createRoot } from "react-dom/client";
@@ -22,7 +22,7 @@ function App() {
 const root = createRoot(document.getElementById('root')!)
 root.render(<App />)
 
-const form = reatomForm(fieldArray => ({
+const form = reatomForm({
 	username: 'vlad',
 	addresses: [
 		{
@@ -39,7 +39,7 @@ const form = reatomForm(fieldArray => ({
 			})
 		}
 	],
-}), {
+}, {
 	validateOnChange: true,
 	schema: z.object({
 		username: z.string().min(3, 'min length 3'),

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -2,10 +2,11 @@ import { AtomState, createCtx } from "@reatom/core";
 import { connectLogger } from "@reatom/logger"
 import { reatomContext, useAction, useAtom } from "@reatom/npm-react"
 import { FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
-import { LinkedListAtom, LinkedListLikeAtom, reatomBoolean } from "@reatom/primitives";
+import { LinkedListLikeAtom, reatomBoolean } from "@reatom/primitives";
 import { PropsWithChildren } from 'react';
 import { createRoot } from "react-dom/client";
 import { useFormField } from "./use-form-field";
+import { z } from "zod";
 
 const ctx = createCtx();
 connectLogger(ctx);
@@ -38,7 +39,26 @@ const form = reatomForm(fieldArray => ({
 			})
 		}
 	],
-}));
+}), {
+	validateOnChange: true,
+	schema: z.object({
+		username: z.string().min(3, 'min length 3'),
+		addresses: z.array(
+			z.object({
+				country: z.string().min(3, 'min length 3'),
+				street: z.string(),
+				city: z.string(),
+				tags: z.array(z.string().min(3, 'min length 3')),
+				phoneNumbers: z.array(
+					z.object({
+						number: z.string(),
+						priority: z.boolean()
+					})
+				)
+			})
+		)
+	})
+});
 
 const vStack = { display: 'flex', flexDirection: 'column', gap: '1rem' } as const;
 
@@ -60,6 +80,7 @@ function Form() {
 				style={{ ...vStack, gap: '0.5rem', width: '100%', maxWidth: '20rem' }}
 			>
 				<input {...usernameField.getInputProps()} />
+				<FieldError error={usernameField.error} />
 
 				<AddressesField />
 			</form>
@@ -118,14 +139,17 @@ function AddressField({ model }: { model: AddressFieldType }) {
 		<div style={{ ...vStack, gap: '0.5rem', border: '1px solid black', padding: '0.5rem' }}>
 			<label>
 				Country <input {...countryField.getInputProps()} />
+				<FieldError error={countryField.error} />
 			</label>
 
 			<label>
 				Street <input {...streetField.getInputProps()} />
+				<FieldError error={streetField.error} />
 			</label>
 
 			<label>
 				City <input {...cityField.getInputProps()} />
+				<FieldError error={cityField.error} />
 			</label>
 
 			<TagsField model={model.tags} />
@@ -163,9 +187,13 @@ function TagField({ model, children }: PropsWithChildren<{ model: FieldAtom<stri
 
 	return (
 		<div
-			style={{ display: 'flex', gap: '0.25rem' }}
+			style={{ display: 'flex', alignItems: 'start', gap: '0.25rem' }}
 		>
-			<input {...field.getInputProps()} style={{ maxWidth: '4rem' }} />
+			<div>
+				<input {...field.getInputProps()} style={{ maxWidth: '4rem' }} />
+				<FieldError error={field.error} />
+			</div>
+
 			{children}
 		</div>
 	)
@@ -207,6 +235,7 @@ function PhoneNumberField({ model, children }: PropsWithChildren<{ model: PhoneN
 			style={{ display: 'flex', gap: '0.25rem' }}
 		>
 			<input {...numberField.getInputProps()} />
+			<FieldError error={numberField.error} />
 
 			<label>
 				priority
@@ -215,6 +244,10 @@ function PhoneNumberField({ model, children }: PropsWithChildren<{ model: PhoneN
 			{children}
 		</div>
 	)
+}
+
+function FieldError({ error }: { error: string | undefined }) {
+	return error ? <div style={{ color: 'red' }}>{error}</div> : null;
 }
 
 function FieldsState() {

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -1,7 +1,7 @@
 import { AtomState, createCtx } from "@reatom/core";
 import { connectLogger } from "@reatom/logger"
 import { reatomContext, useAction, useAtom } from "@reatom/npm-react"
-import { fieldArray, FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
+import { experimental_fieldArray, FieldAtom, FormFieldArrayAtom, reatomForm, withField } from "../src";
 import { LinkedListLikeAtom, reatomBoolean } from "@reatom/primitives";
 import { PropsWithChildren } from 'react';
 import { createRoot } from "react-dom/client";
@@ -30,7 +30,7 @@ const form = reatomForm(name => ({
 			street: 'my street',
 			city: 'my city',
 			tags: ['defaultTag', 'defaultTag2'],
-			phoneNumbers: fieldArray({
+			phoneNumbers: experimental_fieldArray({
 				initState: Array<{ number: string, priority: boolean }>(),
 				create: (ctx, { number, priority }, name) => ({
 					number,

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -22,7 +22,7 @@ function App() {
 const root = createRoot(document.getElementById('root')!)
 root.render(<App />)
 
-const form = reatomForm({
+const form = reatomForm(name => ({
 	username: 'vlad',
 	addresses: [
 		{
@@ -32,14 +32,14 @@ const form = reatomForm({
 			tags: ['defaultTag', 'defaultTag2'],
 			phoneNumbers: fieldArray({
 				initState: Array<{ number: string, priority: boolean }>(),
-				create: (ctx, { number, priority }) => ({
+				create: (ctx, { number, priority }, name) => ({
 					number,
-					priority: reatomBoolean(priority).pipe(withField(priority))
+					priority: reatomBoolean(priority, `${name}.priority`).pipe(withField(priority))
 				})
 			})
 		}
 	],
-}, {
+}), {
 	validateOnChange: true,
 	schema: z.object({
 		username: z.string().min(3, 'min length 3'),

--- a/packages/form/sandbox/index.tsx
+++ b/packages/form/sandbox/index.tsx
@@ -34,7 +34,7 @@ const form = reatomForm(name => ({
 				initState: Array<{ number: string, priority: boolean }>(),
 				create: (ctx, { number, priority }, name) => ({
 					number,
-					priority: reatomBoolean(priority, `${name}.priority`).pipe(withField(priority))
+					priority: reatomBoolean(priority, `${name}.priority`).pipe(withField())
 				})
 			})
 		}

--- a/packages/form/sandbox/use-form-field.tsx
+++ b/packages/form/sandbox/use-form-field.tsx
@@ -1,0 +1,50 @@
+import { useAction, useAtom } from "@reatom/npm-react";
+import { ChangeEvent, HTMLInputTypeAttribute, useCallback } from "react";
+import { FieldValidation, FieldAtom } from "../src";
+
+type UseFormFieldReturn<State, Value = State> = FieldValidation & {
+	getInputProps: () => {
+		value: string;
+		onBlur: () => void;
+		onFocus: () => void;
+		onChange: (evOrVal: ChangeEvent<{ value: Value; } | { checked: Value; }> | Value) => void;
+	};
+};
+
+export function useFormField(model: FieldAtom<boolean>, type: 'checkbox'): UseFormFieldReturn<boolean>;
+export function useFormField<State, Value>(
+	model: FieldAtom<State, Value>, type?: Exclude<'checkbox', string>): UseFormFieldReturn<State, Value>;
+
+export function useFormField<State, Value>(model: FieldAtom<State, Value>, type: HTMLInputTypeAttribute = 'text') {
+	const change = useAction(model.change);
+	const focus = useAction(model.focus.in);
+	const blur = useAction(model.focus.out);
+	const [validation] = useAtom(model.validation);
+	const [value] = useAtom(model.value);
+
+	const onBlur = useCallback(() => blur(), [blur]);
+	const onFocus = useCallback(() => focus(), [focus]);
+	const onChange = useCallback((evOrVal: ChangeEvent<{ value: Value; } | { checked: Value; }> | Value) => {
+		if (evOrVal && typeof evOrVal === 'object' && 'target' in evOrVal) {
+			if (type === 'checkbox' && 'checked' in evOrVal.target)
+				change(evOrVal.target.checked);
+			else if ('value' in evOrVal.target)
+				change(evOrVal.target.value);
+		}
+		else {
+			change(evOrVal);
+		}
+	}, [change, type]);
+
+	const getInputProps = useCallback(() => ({
+		value: String(value),
+		onChange,
+		onBlur,
+		onFocus,
+	}), [onChange, onBlur, onFocus, value]);
+
+	return {
+		getInputProps,
+		...validation,
+	};
+}

--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -1,6 +1,0 @@
-import { test, expect } from 'vitest'
-
-test('base API', async () => {
-  // expect.fail('You forgot to test your code')
-  expect(true).toBe(true) // Placeholder for an actual test
-})

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,2 +1,3 @@
 export * from './reatomField'
 export * from './reatomForm'
+export * from './reatomFieldSet'

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -1,0 +1,82 @@
+import { test, expect, vi, assert } from 'vitest'
+import { createCtx } from '@reatom/core'
+import { reatomField, withField } from '.'
+import { reatomEnum } from '@reatom/primitives';
+
+test(`validateOnChange`, async () => {
+  const ctx = createCtx();
+  const field = reatomField('', { name: 'fieldAtom', validateOnChange: true });
+  const changeFn = vi.fn();
+  field.validation.trigger.onCall(() => changeFn());
+
+  field.change(ctx, 'value');
+  expect(changeFn).toHaveBeenCalledTimes(1);
+})
+
+test(`validateOnBlur`, async () => {
+  const ctx = createCtx();
+  const field = reatomField('', { name: 'fieldAtom', validateOnBlur: true });
+  const blurFn = vi.fn();
+  field.validation.trigger.onCall(() => blurFn());
+
+  field.focus.out(ctx);
+  expect(blurFn).toHaveBeenCalledTimes(1);
+})
+
+test(`keepErrorOnChange`, async () => {
+  const ctx = createCtx()
+  const validate = () => {
+    throw new Error('validation error');
+  }
+
+  const fieldWithKeep = reatomField('', {
+    name: 'fieldKeep',
+    validate,
+    keepErrorOnChange: true
+  })
+
+  const fieldWithoutKeep = reatomField('', {
+    name: 'fieldNoKeep',
+    validate,
+    keepErrorOnChange: false
+  })
+
+  fieldWithKeep.validation.trigger(ctx)
+  fieldWithoutKeep.validation.trigger(ctx)
+
+  expect(ctx.get(fieldWithKeep.validation).error).toBe('validation error')
+  expect(ctx.get(fieldWithoutKeep.validation).error).toBe('validation error')
+
+  fieldWithKeep.change(ctx, 'new value')
+  fieldWithoutKeep.change(ctx, 'new value')
+
+  expect(ctx.get(fieldWithKeep.validation).error).toBe('validation error')
+  expect(ctx.get(fieldWithoutKeep.validation).error).toBeUndefined()
+})
+
+test(`toState and fromState`, async () => {
+  const ctx = createCtx()
+  const label = 'label';
+
+  const field = reatomField({ label, value: 1337 }, {
+    name: 'fieldAtom',
+    fromState: (ctx, state) => state.value,
+    toState: (ctx, value) => ({ label, value }),
+  });
+
+  field(ctx, { label, value: 1000 });
+  expect(ctx.get(field.value)).toEqual(1000);
+
+  field.change(ctx, 2000);
+  expect(ctx.get(field)).toEqual({ label, value: 2000 });
+})
+
+test(`withField`, async () => {
+  const ctx = createCtx()
+  const field = reatomEnum(['lel', 'kek', 'shmek'], 'fieldAtom').pipe(withField('lel'));
+
+  field.setLel(ctx);
+  expect(ctx.get(field)).toBe('lel');
+
+  expect(field.value.__reatom.name).toBe('fieldAtom.value');
+})

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi, assert } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { reatomField, withField } from '.'
-import { reatomEnum, reatomLinkedList } from '@reatom/primitives';
+import { reatomEnum } from '@reatom/primitives';
 
 test(`validateOnChange`, async () => {
   const ctx = createCtx();

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi, assert } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { reatomField, withField } from '.'
-import { reatomEnum } from '@reatom/primitives';
+import { reatomEnum, reatomLinkedList } from '@reatom/primitives';
 
 test(`validateOnChange`, async () => {
   const ctx = createCtx();

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -1,7 +1,7 @@
-import { test, expect, vi, assert } from 'vitest'
+import { test, expect, vi } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { reatomField, withField } from '.'
-import { reatomEnum, reatomLinkedList } from '@reatom/primitives';
+import { reatomEnum } from '@reatom/primitives';
 
 test(`validateOnChange`, async () => {
   const ctx = createCtx();

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -73,9 +73,13 @@ test(`toState and fromState`, async () => {
 
 test(`withField`, async () => {
   const ctx = createCtx()
-  const field = reatomEnum(['lel', 'kek', 'shmek'], 'fieldAtom').pipe(withField('lel'));
+  const field = reatomEnum(['lel', 'kek', 'shmek'], 'fieldAtom').pipe(withField());
 
-  field.setLel(ctx);
+  expect(ctx.get(field)).toBe('lel');
+  field.setKek(ctx);
+  expect(ctx.get(field)).toBe('kek');
+
+  field.reset(ctx);
   expect(ctx.get(field)).toBe('lel');
 
   expect(field.value.__reatom.name).toBe('fieldAtom.value');

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -57,7 +57,7 @@ test(`keepErrorOnChange`, async () => {
 
 test(`keepErrorDuringValidating`, async () => {
   const ctx = createCtx()
-  
+
   const validate = async () => {
     await sleep()
     throw new Error('validation error');
@@ -96,7 +96,7 @@ test(`keepErrorDuringValidating`, async () => {
 test(`disabled state`, async () => {
   const ctx = createCtx()
 
-  const field = reatomField('', { 
+  const field = reatomField('', {
     validateOnChange: true,
     contract: (value) => {
       if (value == 'errorValue')
@@ -153,7 +153,7 @@ test(`validation concurrency`, async () => {
   field.reset(ctx);
   expect(ctx.get(field.validation)).toMatchObject(fieldInitValidation);
 
-  field.validateOnChange(ctx, true);
+  field.options.merge(ctx, { validateOnChange: true });
 
   field.change(ctx, 1);
   field.change(ctx, 0xDEADBEEF);

--- a/packages/form/src/reatomField.test.ts
+++ b/packages/form/src/reatomField.test.ts
@@ -1,7 +1,8 @@
 import { test, expect, vi } from 'vitest'
 import { createCtx } from '@reatom/core'
-import { reatomField, withField } from '.'
+import { fieldInitValidation, reatomField, withField } from '.'
 import { reatomEnum } from '@reatom/primitives';
+import { sleep } from '@reatom/utils';
 
 test(`validateOnChange`, async () => {
   const ctx = createCtx();
@@ -54,6 +55,65 @@ test(`keepErrorOnChange`, async () => {
   expect(ctx.get(fieldWithoutKeep.validation).error).toBeUndefined()
 })
 
+test(`keepErrorDuringValidating`, async () => {
+  const ctx = createCtx()
+  
+  const validate = async () => {
+    await sleep()
+    throw new Error('validation error');
+  }
+
+  const fieldWithKeep = reatomField('', {
+    name: 'fieldKeep',
+    validate,
+    keepErrorDuringValidating: true
+  })
+
+  const fieldWithoutKeep = reatomField('', {
+    name: 'fieldNoKeep',
+    validate,
+    keepErrorDuringValidating: false
+  })
+
+  fieldWithKeep.validation.trigger(ctx)
+  fieldWithoutKeep.validation.trigger(ctx)
+
+  await sleep();
+
+  expect(ctx.get(fieldWithKeep.validation).error).toBe('validation error')
+  expect(ctx.get(fieldWithoutKeep.validation).error).toBe('validation error')
+
+  fieldWithKeep.change(ctx, 'new value')
+  fieldWithoutKeep.change(ctx, 'new value')
+
+  fieldWithKeep.validation.trigger(ctx)
+  fieldWithoutKeep.validation.trigger(ctx)
+
+  expect(ctx.get(fieldWithKeep.validation).error).toBe('validation error')
+  expect(ctx.get(fieldWithoutKeep.validation).error).toBeUndefined()
+})
+
+test(`disabled state`, async () => {
+  const ctx = createCtx()
+
+  const field = reatomField('', { 
+    validateOnChange: true,
+    contract: (value) => {
+      if (value == 'errorValue')
+        throw new Error('validation error');
+    }
+  });
+
+  field.change(ctx, 'errorValue');
+  expect(ctx.get(field.validation).error).toBe('validation error');
+
+  field.disabled(ctx, true);
+  expect(ctx.get(field.validation)).toMatchObject(fieldInitValidation);
+
+  field.disabled(ctx, false);
+  expect(ctx.get(field.validation).error).toBe('validation error');
+})
+
 test(`toState and fromState`, async () => {
   const ctx = createCtx()
   const label = 'label';
@@ -71,7 +131,43 @@ test(`toState and fromState`, async () => {
   expect(ctx.get(field)).toEqual({ label, value: 2000 });
 })
 
-test(`withField`, async () => {
+test(`validation concurrency`, async () => {
+  const ctx = createCtx()
+  const field = reatomField(123, {
+    validate: async (ctx, { value }) => {
+      await sleep();
+
+      if (value === 0xDEADBEEF)
+        throw new Error('validation error');
+    }
+  });
+
+  field.validation.trigger(ctx);
+  expect(ctx.get(field.validation)).toMatchObject({ validating: true, triggered: true, error: undefined });
+  field.change(ctx, 1);
+
+  expect(ctx.get(field.validation)).toMatchObject(fieldInitValidation);
+
+  field.validation.trigger(ctx);
+  expect(ctx.get(field.validation)).toMatchObject({ validating: true, triggered: true, error: undefined });
+  field.reset(ctx);
+  expect(ctx.get(field.validation)).toMatchObject(fieldInitValidation);
+
+  field.validateOnChange(ctx, true);
+
+  field.change(ctx, 1);
+  field.change(ctx, 0xDEADBEEF);
+  field.change(ctx, 3);
+
+  expect(ctx.get(field.validation)).toMatchObject({ validating: true, triggered: true, error: undefined });
+
+  await sleep();
+
+  expect(ctx.get(field.validation)).toMatchObject({ validating: false, triggered: true, error: undefined });
+  expect(ctx.get(field.value)).toBe(3);
+})
+
+test(`withField and initState derivation`, async () => {
   const ctx = createCtx()
   const field = reatomEnum(['lel', 'kek', 'shmek'], 'fieldAtom').pipe(withField());
 

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -1,16 +1,9 @@
-import {
-  action,
-  Action,
-  Atom,
-  atom,
-  AtomMut,
-  Ctx,
-  __count,
-  AtomCache,
-} from '@reatom/core'
+import { type Action, type Atom, type AtomMut, type Ctx, __count, action, atom } from '@reatom/core'
 import { __thenReatomed } from '@reatom/effects'
-import { RecordAtom, reatomRecord } from '@reatom/primitives'
+import { type CtxSpy, abortCauseContext, withAbortableSchedule } from '@reatom/framework'
+import { type RecordAtom, reatomRecord } from '@reatom/primitives'
 import { isDeepEqual, noop, toAbortError } from '@reatom/utils'
+
 import { toError } from './utils'
 
 export interface FieldFocus {
@@ -28,62 +21,63 @@ export interface FieldValidation {
   /** The field validation error text. */
   error: undefined | string
 
-  /** The field validation status. */
-  valid: boolean
+  /** The field validation meta. */
+  meta: unknown | undefined
+
+  /** The validation actuality status. */
+  triggered: boolean
 
   /** The field async validation status */
   validating: boolean
 }
 
-export interface FieldActions<Value = any> {
-  /** Action for handling field blur. */
-  blur: Action<[], void>
+export interface FocusAtom extends RecordAtom<FieldFocus> {
+  /** Action for handling field focus. */
+  in: Action<[], void>
 
+  /** Action for handling field blur. */
+  out: Action<[], void>
+}
+
+export interface ValidationAtom extends RecordAtom<FieldValidation> {
+  /** Action to trigger field validation. */
+  trigger: Action<[], FieldValidation>
+}
+
+export interface FieldAtom<State = any, Value = State> extends AtomMut<State> {
   /** Action for handling field changes, accepts the "value" parameter and applies it to `toState` option. */
   change: Action<[Value], Value>
 
-  /** Action for handling field focus. */
-  focus: Action<[], void>
+  /** Atom of an object with all related focus statuses. */
+  focus: FocusAtom
+
+  /** The initial state of the atom. */
+  initState: AtomMut<State>
 
   /** Action to reset the state, the value, the validation, and the focus. */
   reset: Action<[], void>
 
-  /** Action to trigger field validation. */
-  validate: Action<[], FieldValidation>
-}
-
-export interface FieldAtom<State = any, Value = State>
-  extends AtomMut<State>,
-    FieldActions<Value> {
-  /** Atom of an object with all related focus statuses. */
-  focusAtom: RecordAtom<FieldFocus>
-
-  /** The initial state of the atom, readonly. */
-  initState: State
-
   /** Atom of an object with all related validation statuses. */
-  validationAtom: RecordAtom<FieldValidation>
+  validation: ValidationAtom
 
   /** Atom with the "value" data, computed by the `fromState` option */
-  valueAtom: Atom<Value>
+  value: Atom<Value>
 }
 
-export interface FieldValidateOption<State = any, Value = State> {
-  (
-    ctx: Ctx,
-    meta: {
-      state: State
-      value: Value
-      focus: FieldFocus
-      validation: FieldValidation
-    },
-  ): any
-}
+export type FieldValidateOption<State = any, Value = State> = (
+  ctx: Ctx,
+  meta: {
+    state: State
+    value: Value
+    focus: FieldFocus
+    validation: FieldValidation
+  },
+) => any
 
 export interface FieldOptions<State = any, Value = State> {
   /**
    * The callback to filter "value" changes (from the 'change' action). It should return 'false' to skip the update.
-   * By default, it always returns `false`.
+   * By default, it always returns `true`.
    */
   filter?: (ctx: Ctx, newValue: Value, prevValue: Value) => boolean
 
@@ -91,12 +85,7 @@ export interface FieldOptions<State = any, Value = State> {
    * The callback to compute the "value" data from the "state" data.
    * By default, it returns the "state" data without any transformations.
    */
-  fromState?: (ctx: Ctx, state: State) => Value
-
-  /**
-   * The initial state of the atom, which is the only required option.
-   */
-  initState: State
+  fromState?: (ctx: CtxSpy, state: State) => Value
 
   /**
    * The callback used to determine whether the "value" has changed.
@@ -121,29 +110,34 @@ export interface FieldOptions<State = any, Value = State> {
   validate?: FieldValidateOption<State, Value>
 
   /**
+   * The callback to validate field contract.
+   */
+  contract?: (state: State) => any
+
+  /**
    * Defines the reset behavior of the validation state during async validation.
-   * It is `false` by default.
+   * @default false
    */
   keepErrorDuringValidating?: boolean
 
   /**
-   * @deprecated Use boolean flags instead. It is `blur` by default.
+   * Defines the reset behavior of the validation state on field change.
+   * Useful if the validation is triggered on blur or submit only.
+   * @default !validateOnChange
    */
-  validationTrigger?: 'change' | 'blur' | 'submit'
+  keepErrorOnChange?: boolean
 
   /**
-   * Defines if the validation should be triggered with every field change. By default computes from the `validationTrigger` option and `!validateOnBlur`.
+   * Defines if the validation should be triggered with every field change.
+   * @default false
    */
   validateOnChange?: boolean
 
   /**
-   * Defines if the validation should be triggered on the field blur. By default computes from the `validationTrigger` option.
+   * Defines if the validation should be triggered on the field blur.
+   * @default false
    */
   validateOnBlur?: boolean
-}
-
-interface AbortableCause extends AtomCache {
-  controller: AbortController
 }
 
 export const fieldInitFocus: FieldFocus = {
@@ -154,94 +148,106 @@ export const fieldInitFocus: FieldFocus = {
 
 export const fieldInitValidation: FieldValidation = {
   error: undefined,
-  valid: false,
+  meta: undefined,
+  triggered: false,
   validating: false,
 }
 
 export const fieldInitValidationLess: FieldValidation = {
   error: undefined,
-  valid: true,
+  meta: undefined,
+  triggered: true,
   validating: false,
 }
 
 export const reatomField = <State, Value>(
-  {
-    filter = () => true,
-    fromState = (ctx, state) => state as unknown as Value,
-    initState,
-    isDirty = (ctx, newValue, prevValue) => !isDeepEqual(newValue, prevValue),
-    name: optionsName,
-    toState = (ctx, value) => value as unknown as State,
-    validate: validateFn,
-    keepErrorDuringValidating = false,
-    validationTrigger = 'blur',
-    validateOnBlur = validationTrigger === 'blur',
-    validateOnChange = validationTrigger === 'change' && !validateOnBlur,
-  }: FieldOptions<State, Value>,
-  // this is out of the options for eslint compatibility
-  name = optionsName ?? __count(`${typeof initState}Field`),
+  _initState: State,
+  options: string | FieldOptions<State, Value> = {},
 ): FieldAtom<State, Value> => {
   interface This extends FieldAtom<State, Value> {}
-  const fieldAtom = atom(initState, `${name}.fieldAtom`) as This
 
-  const valueAtom: This['valueAtom'] = atom(
-    (ctx) => fromState(ctx, ctx.spy(fieldAtom)),
-    `${name}.valueAtom`,
-  )
+  const {
+    filter = () => true,
+    fromState = (ctx, state) => state as unknown as Value,
+    isDirty = (ctx, newValue, prevValue) => !isDeepEqual(newValue, prevValue),
+    name = __count(`${typeof _initState}Field`),
+    toState = (ctx, value) => value as unknown as State,
+    validate: validateFn,
+    contract,
+    validateOnBlur = false,
+    validateOnChange = false,
+    keepErrorDuringValidating = false,
+    keepErrorOnChange = validateOnChange,
+  } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
 
-  const focusAtom: This['focusAtom'] = reatomRecord(
-    fieldInitFocus,
-    `${name}.focusAtom`,
-  )
-  // @ts-expect-error
-  focusAtom.__reatom.computer = (ctx, state: FieldFocus) => {
-    const dirty = isDirty(ctx, ctx.spy(valueAtom), fromState(ctx, initState))
+  const initState = atom(_initState, `${name}.initState`)
+
+  const field = atom(_initState, `${name}.field`) as This
+
+  const value: This['value'] = atom((ctx) => fromState(ctx, ctx.spy(field)), `${name}.value`)
+
+  const focus = reatomRecord(fieldInitFocus, `${name}.focus`) as This['focus']
+  // @ts-expect-error the original computed state can't be typed properly
+  focus.__reatom.computer = (ctx, state: FieldFocus) => {
+    const dirty = isDirty(ctx, ctx.spy(value), fromState(ctx, ctx.spy(initState)))
     return state.dirty === dirty ? state : { ...state, dirty }
   }
 
-  const validationAtom: This['validationAtom'] = reatomRecord(
-    validateFn ? fieldInitValidation : fieldInitValidationLess,
-    `${name}.validationAtom`,
-  )
-  if (validateFn) {
-    // @ts-expect-error
-    validationAtom.__reatom.computer = (ctx, state: FieldValidation) => {
-      ctx.spy(valueAtom)
-      return state.valid ? { ...state, valid: false } : state
+  focus.in = action((ctx) => {
+    focus.merge(ctx, { active: true })
+  }, `${name}.focus.in`)
+
+  focus.out = action((ctx) => {
+    focus.merge(ctx, { active: false, touched: true })
+  }, `${name}.focus.out`)
+
+  const validation = reatomRecord(
+    validateFn || contract ? fieldInitValidation : fieldInitValidationLess,
+    `${name}.validation`,
+  ) as This['validation']
+  if (validateFn || contract) {
+    // @ts-expect-error the original computed state can't be typed properly
+    validation.__reatom.computer = (ctx, state: FieldValidation) => {
+      ctx.spy(value)
+      return state.triggered ? { ...state, triggered: false } : state
     }
   }
 
-  const validateControllerAtom = atom(
-    new AbortController(),
-    `${name}.validateControllerAtom`,
-  )
+  const validationController = atom(new AbortController(), `${name}._validationController`)
   // prevent collisions for different contexts
-  validateControllerAtom.__reatom.initState = () => new AbortController()
-  const validate: This['validate'] = action((ctx) => {
-    const validation = ctx.get(validationAtom)
+  validationController.__reatom.initState = () => new AbortController()
 
-    if (validation.valid) return validation
-    if (!validateFn) return validationAtom.merge(ctx, { valid: true })
+  validation.trigger = action((ctx) => {
+    const validationValue = ctx.get(validation)
 
-    ctx.get(validateControllerAtom).abort(toAbortError('concurrent'))
-    const controller = validateControllerAtom(
-      ctx,
-      ((ctx.cause as AbortableCause).controller = new AbortController()),
-    )
+    if (validationValue.triggered) return validationValue
+    if (!validateFn && !contract) {
+      return validation.merge(ctx, { triggered: true })
+    }
 
-    const state = ctx.get(fieldAtom)
-    const value = ctx.get(valueAtom)
-    const focus = ctx.get(focusAtom)
+    ctx.get(validationController).abort(toAbortError('concurrent'))
+
+    const controller = validationController(ctx, new AbortController())
+    abortCauseContext.set(ctx.cause, controller)
+
+    const state = ctx.get(field)
+    const valueValue = ctx.get(value)
+    const focusValue = ctx.get(focus)
+    let promise: any
+    let message: undefined | string
 
     try {
-      var promise = validateFn(ctx, {
+      contract?.(state)
+      // eslint-disable-next-line no-var
+      promise = validateFn?.(withAbortableSchedule(ctx), {
         state,
-        value,
-        focus,
-        validation,
+        value: valueValue,
+        focus: focusValue,
+        validation: validationValue,
       })
     } catch (error) {
-      var message: undefined | string = toError(error)
+      // eslint-disable-next-line no-var
+      message = toError(error)
     }
 
     if (promise instanceof Promise) {
@@ -250,80 +256,79 @@ export const reatomField = <State, Value>(
         promise,
         () => {
           if (controller.signal.aborted) return
-          validationAtom.merge(ctx, {
+          validation.merge(ctx, {
             error: undefined,
-            valid: true,
+            meta: undefined,
+            triggered: true,
             validating: false,
           })
         },
         (error) => {
           if (controller.signal.aborted) return
-          validationAtom.merge(ctx, {
+          validation.merge(ctx, {
             error: toError(error),
-            valid: true,
+            meta: undefined,
+            triggered: true,
             validating: false,
           })
         },
       ).catch(noop)
 
-      return validationAtom.merge(ctx, {
-        error: keepErrorDuringValidating ? validation.error : undefined,
-        valid: true,
+      return validation.merge(ctx, {
+        error: keepErrorDuringValidating ? validationValue.error : undefined,
+        meta: undefined,
+        triggered: true,
         validating: true,
       })
     }
 
-    return validationAtom.merge(ctx, {
+    return validation.merge(ctx, {
       validating: false,
       error: message,
-      valid: true,
+      meta: undefined,
+      triggered: true,
     })
-  }, `${name}.validate`)
-
-  const focus: This['focus'] = action((ctx) => {
-    focusAtom.merge(ctx, { active: true })
-  }, `${name}.focus`)
-
-  const blur: This['blur'] = action((ctx) => {
-    focusAtom.merge(ctx, { active: false, touched: true })
-  }, `${name}.blur`)
+  }, `${name}.validation.trigger`)
 
   const change: This['change'] = action((ctx, newValue) => {
-    const prevValue = ctx.get(valueAtom)
+    const prevValue = ctx.get(value)
 
     if (!filter(ctx, newValue, prevValue)) return prevValue
 
-    fieldAtom(ctx, toState(ctx, newValue))
-    focusAtom.merge(ctx, { touched: true })
+    field(ctx, toState(ctx, newValue))
+    focus.merge(ctx, { touched: true })
 
-    return ctx.get(valueAtom)
+    return ctx.get(value)
   }, `${name}.change`)
 
   const reset: This['reset'] = action((ctx) => {
-    fieldAtom(ctx, initState)
-    focusAtom(ctx, fieldInitFocus)
-    validationAtom(ctx, fieldInitValidation)
-    ctx.get(validateControllerAtom).abort(toAbortError('reset'))
+    field(ctx, ctx.get(initState))
+    focus(ctx, fieldInitFocus)
+    validation(ctx, fieldInitValidation)
+    ctx.get(validationController).abort(toAbortError('reset'))
   }, `${name}.reset`)
 
+  if (!keepErrorOnChange) {
+    field.onChange((ctx) => {
+      validation(ctx, fieldInitValidation)
+      ctx.get(validationController).abort(toAbortError('change'))
+    })
+  }
+
   if (validateOnChange) {
-    fieldAtom.onChange((ctx) => validate(ctx))
+    field.onChange((ctx) => validation.trigger(ctx))
   }
 
   if (validateOnBlur) {
-    blur.onCall((ctx) => validate(ctx))
+    focus.out.onCall((ctx) => validation.trigger(ctx))
   }
 
-  return Object.assign(fieldAtom, {
-    blur,
+  return Object.assign(field, {
     change,
     focus,
-    reset,
-    validate,
-
-    focusAtom,
     initState,
-    validationAtom,
-    valueAtom,
+    reset,
+    validation,
+    value,
   })
 }

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -181,7 +181,7 @@ export const reatomField = <State, Value = State>(
     validateOnBlur = false,
     validateOnChange = false,
     keepErrorDuringValidating = false,
-    keepErrorOnChange = validateOnChange,
+    keepErrorOnChange = !validateOnChange,
   } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
 
   const initState = atom(_initState, `${name}.initState`)

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -43,7 +43,11 @@ export interface ValidationAtom extends RecordAtom<FieldValidation> {
   trigger: Action<[], FieldValidation>
 }
 
-export interface FieldAtom<State = any, Value = State> extends AtomMut<State> {
+export interface FieldLikeAtom<State = any> extends AtomMut<State> {
+  __reatomField: true
+}
+
+export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<State> {
   /** Action for handling field changes, accepts the "value" parameter and applies it to `toState` option. */
   change: Action<[Value], Value>
 
@@ -159,7 +163,7 @@ export const fieldInitValidationLess: FieldValidation = {
   validating: false,
 }
 
-export const reatomField = <State, Value>(
+export const reatomField = <State, Value = State>(
   _initState: State,
   options: string | FieldOptions<State, Value> = {},
   _stateAtom?: AtomMut<State>
@@ -329,6 +333,8 @@ export const reatomField = <State, Value>(
     reset,
     validation,
     value,
+
+    __reatomField: true as const
   })
 }
 
@@ -341,3 +347,5 @@ export const withField = <T extends AtomMut, Value = AtomState<T>>(
     reatomField(_initState, { name: anAtom.__reatom.name, ...options }, anAtom)
   );
 }
+
+export const isFieldAtom = (thing: any): thing is FieldLikeAtom => thing?.__reatomField === true

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -65,6 +65,15 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
 
   /** Atom with the "value" data, computed by the `fromState` option */
   value: Atom<Value>
+
+	/** @internal */
+	__defaults: {
+		keepErrorDuringValidating?: boolean
+		keepErrorOnChange?: boolean
+		validateOnChange?: boolean
+		validateOnBlur?: boolean
+		shouldValidate?: boolean
+	};
 }
 
 export type FieldValidateOption<State = any, Value = State> = (
@@ -178,11 +187,25 @@ export const reatomField = <State, Value = State>(
     toState = (ctx, value) => value as unknown as State,
     validate: validateFn,
     contract,
-    validateOnBlur = false,
-    validateOnChange = false,
-    keepErrorDuringValidating = false,
-    keepErrorOnChange = !validateOnChange,
+    ...restOptions
   } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
+
+	const reactiveOptions = Object.assign(restOptions, { shouldValidate: false })
+
+	const validateOnBlur = atom(false, `${name}.validateOnBlur`)
+  validateOnBlur.__reatom.initState = () => reactiveOptions.validateOnBlur ?? false
+
+	const validateOnChange = atom(false, `${name}.validateOnChange`)
+  validateOnChange.__reatom.initState = () => reactiveOptions.validateOnChange ?? false
+
+	const keepErrorDuringValidating = atom(false, `${name}.keepErrorDuringValidating`)
+  keepErrorDuringValidating.__reatom.initState = () => reactiveOptions.keepErrorDuringValidating ?? false
+
+	const keepErrorOnChange = atom(false, `${name}.keepErrorOnChange`)
+  keepErrorOnChange.__reatom.initState = (ctx) => reactiveOptions.keepErrorOnChange ?? !ctx.get(validateOnChange)
+
+	const shouldValidate = atom(false, `${name}.shouldValidate`)
+  shouldValidate.__reatom.initState = () => reactiveOptions.shouldValidate ?? !!(validateFn || contract)
 
   const initState = atom(_initState, `${name}.initState`)
 
@@ -206,16 +229,19 @@ export const reatomField = <State, Value = State>(
   }, `${name}.focus.out`)
 
   const validation = reatomRecord(
-    validateFn || contract ? fieldInitValidation : fieldInitValidationLess,
+    fieldInitValidationLess,
     `${name}.validation`,
   ) as This['validation']
 
-  if (validateFn || contract) {
-    // @ts-expect-error the original computed state can't be typed properly
-    validation.__reatom.computer = (ctx, state: FieldValidation) => {
-      ctx.spy(value)
-      return state.triggered ? { ...state, triggered: false } : state
-    }
+  validation.__reatom.initState = ctx => ctx.get(shouldValidate) ? fieldInitValidation : fieldInitValidationLess
+
+  // @ts-expect-error the original computed state can't be typed properly
+  validation.__reatom.computer = (ctx, state: FieldValidation) => {
+    if (!ctx.spy(shouldValidate))
+			return state
+
+    ctx.spy(value)
+    return state.triggered ? { ...state, triggered: false } : state
   }
 
   const validationController = atom(new AbortController(), `${name}._validationController`)
@@ -226,7 +252,7 @@ export const reatomField = <State, Value = State>(
     const validationValue = ctx.get(validation)
 
     if (validationValue.triggered) return validationValue
-    if (!validateFn && !contract) {
+    if (!ctx.get(shouldValidate)) {
       return validation.merge(ctx, { triggered: true })
     }
 
@@ -278,7 +304,7 @@ export const reatomField = <State, Value = State>(
       ).catch(noop)
 
       return validation.merge(ctx, {
-        error: keepErrorDuringValidating ? validationValue.error : undefined,
+        error: ctx.get(keepErrorDuringValidating) ? validationValue.error : undefined,
         meta: undefined,
         triggered: true,
         validating: true,
@@ -311,20 +337,23 @@ export const reatomField = <State, Value = State>(
     ctx.get(validationController).abort(toAbortError('reset'))
   }, `${name}.reset`)
 
-  if (!keepErrorOnChange) {
-    field.onChange((ctx) => {
-      validation(ctx, fieldInitValidation)
-      ctx.get(validationController).abort(toAbortError('change'))
-    })
-  }
+	field.onChange((ctx) => {
+		if (ctx.get(keepErrorOnChange))
+			return
 
-  if (validateOnChange) {
-    field.onChange((ctx) => validation.trigger(ctx))
-  }
+		validation(ctx, fieldInitValidation)
+		ctx.get(validationController).abort(toAbortError('change'))
+	})
 
-  if (validateOnBlur) {
-    focus.out.onCall((ctx) => validation.trigger(ctx))
-  }
+	field.onChange((ctx) => {
+		if (ctx.get(validateOnChange))
+			validation.trigger(ctx)
+	})
+
+	focus.out.onCall((ctx) => {
+		if (ctx.get(validateOnBlur))
+			validation.trigger(ctx)
+	})
 
   return Object.assign(field, {
     change,
@@ -333,7 +362,7 @@ export const reatomField = <State, Value = State>(
     reset,
     validation,
     value,
-
+    __defaults: reactiveOptions,
     __reatomField: true as const
   })
 }

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -91,7 +91,7 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
    */
   validateOnBlur: Atom<boolean>
 
-	/** @internal */
+	/** @internal @deprecated */
 	__defaults: {
 		keepErrorDuringValidating?: boolean
 		keepErrorOnChange?: boolean
@@ -232,10 +232,12 @@ export const reatomField = <State, Value = State>(
 	const shouldValidate = atom(false, `${name}.shouldValidate`)
   shouldValidate.__reatom.initState = () => reactiveOptions.shouldValidate ?? !!(validateFn || contract)
 
+  const field = _stateAtom ?? atom(_initState, `${name}.field`)
   const initState = atom(_initState, `${name}.initState`)
-
-  const field = _stateAtom ?? atom(_initState, `${name}.field`);
-
+  // TODO: make sure it's ok to copy initState of other atom. 
+  // We need to extract initial state from `field` atom here and pass it to `initState` atom
+  initState.__reatom.initState = field.__reatom.initState
+  
   const value: This['value'] = atom((ctx) => fromState(ctx, ctx.spy(field)), `${name}.value`)
 
   const focus = reatomRecord(fieldInitFocus, `${name}.focus`) as This['focus']
@@ -397,12 +399,11 @@ export const reatomField = <State, Value = State>(
 }
 
 export const withField = <T extends AtomMut, Value = AtomState<T>>(
-  _initState: AtomState<T>,
   options: Omit<FieldOptions<AtomState<T>, Value>, 'name'> = {}
 ): ((anAtom: T) => T & FieldAtom<AtomState<T>, Value>) => {
   return (anAtom: T) => Object.assign(
     anAtom,
-    reatomField(_initState, { name: anAtom.__reatom.name, ...options }, anAtom)
+    reatomField(null as AtomState<T>, { name: anAtom.__reatom.name, ...options }, anAtom)
   );
 }
 

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -72,33 +72,35 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
   /** Atom that defines if the field is disabled */
   disabled: BooleanAtom
 
-  /**
-   * Defines the reset behavior of the validation state during async validation.
-   * @default false
-   */
-  keepErrorDuringValidating: AtomMut<boolean | undefined>
+  options: RecordAtom<{
+    /**
+     * Defines the reset behavior of the validation state during async validation.
+     * @default false
+     */
+    keepErrorDuringValidating: boolean | undefined
 
-  /**
-   * Defines the reset behavior of the validation state on field change.
-   * Useful if the validation is triggered on blur or submit only.
-   * @default !validateOnChange
-   */
-  keepErrorOnChange: AtomMut<boolean | undefined>
+    /**
+     * Defines the reset behavior of the validation state on field change.
+     * Useful if the validation is triggered on blur or submit only.
+     * @default !validateOnChange
+     */
+    keepErrorOnChange: boolean | undefined
 
-  /**
-   * Defines if the validation should be triggered with every field change.
-   * @default false
-   */
-  validateOnChange: AtomMut<boolean | undefined>
+    /**
+     * Defines if the validation should be triggered with every field change.
+     * @default false
+     */
+    validateOnChange: boolean | undefined
 
-  /**
-   * Defines if the validation should be triggered on the field blur.
-   * @default false
-   */
-  validateOnBlur: AtomMut<boolean | undefined>
+    /**
+     * Defines if the validation should be triggered on the field blur.
+     * @default false
+     */
+    validateOnBlur: boolean | undefined
 
-  /* @internal */
-  shouldValidate: AtomMut<boolean | undefined>
+    /* @internal */
+    shouldValidate: boolean | undefined
+  }>
 }
 
 export type FieldValidateOption<State = any, Value = State> = (
@@ -233,33 +235,31 @@ export function reatomField<State, Value = State>(
     ...restOptions
   } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
 
-	const validateOnBlur = atom(restOptions.validateOnBlur, `${name}.validateOnBlur`).pipe(
+  const fieldOptions = reatomRecord({
+    validateOnChange: restOptions.validateOnChange,
+    validateOnBlur: restOptions.validateOnBlur,
+    keepErrorDuringValidating: restOptions.keepErrorDuringValidating,
+    keepErrorOnChange: restOptions.keepErrorOnChange,
+    shouldValidate: undefined as boolean | undefined
+  }).pipe(
     withAssign((target, name) => ({
-      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
-    }))
-  )
-
-	const validateOnChange = atom(restOptions.validateOnChange, `${name}.validateOnChange`).pipe(
-    withAssign((target, name) => ({
-      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
-    }))
-  )
-
-	const keepErrorDuringValidating = atom(restOptions.keepErrorDuringValidating, `${name}.keepErrorDuringValidating`).pipe(
-    withAssign((target, name) => ({
-      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
-    }))
-  )
-
-	const keepErrorOnChange = atom(restOptions.keepErrorOnChange, `${name}.keepErrorOnChange`).pipe(
-    withAssign((target, name) => ({
-      value: atom((ctx) => ctx.spy(target) ?? !ctx.spy(validateOnChange.value), `${name}.value`)
-    }))
-  )
-
-	const shouldValidate = atom<boolean | undefined>(undefined, `${name}.shouldValidate`).pipe(
-    withAssign((target, name) => ({
-      value: atom((ctx) => ctx.spy(target) ?? !!(validateFn || contract), `${name}.value`)
+      value: atom((ctx) => {
+        const {
+          validateOnChange, 
+          validateOnBlur, 
+          keepErrorDuringValidating,
+          keepErrorOnChange,
+          shouldValidate
+        } = ctx.spy(target)
+        
+        return {
+          validateOnChange: validateOnChange ?? false,
+          validateOnBlur: validateOnBlur ?? false,
+          keepErrorDuringValidating: keepErrorDuringValidating ?? false,
+          keepErrorOnChange: keepErrorOnChange ?? !validateOnChange,
+          shouldValidate: shouldValidate ?? !!(validateFn || contract)
+        }
+      }, `${name}.value`)
     }))
   )
 
@@ -282,12 +282,12 @@ export function reatomField<State, Value = State>(
 		ctx.get(validationController).abort(toAbortError('change'))
 
     validation.merge(ctx,
-      ctx.get(keepErrorOnChange.value)
-        ? { validating: false, triggered: false }
-        : { validating: false, triggered: false, error: undefined }
+      ctx.get(fieldOptions.value).keepErrorOnChange
+        ? { validating: false }
+        : { validating: false, error: undefined }
     )
 
-    if (!ctx.get(disabled) && ctx.get(validateOnChange.value))
+    if (!ctx.get(disabled) && ctx.get(fieldOptions.value).validateOnChange)
 			validation.trigger(ctx)
 	})
 
@@ -311,7 +311,7 @@ export function reatomField<State, Value = State>(
   }
 
   focus.out.onCall((ctx) => {
-		if (!ctx.get(disabled) && ctx.get(validateOnBlur.value))
+		if (!ctx.get(disabled) && ctx.get(fieldOptions.value).validateOnBlur)
 			validation.trigger(ctx)
 	})
 
@@ -328,7 +328,7 @@ export function reatomField<State, Value = State>(
         const validationValue = ctx.get(target)
     
         if (validationValue.triggered) return validationValue
-        if (!ctx.get(shouldValidate.value)) {
+        if (!ctx.get(fieldOptions.value).shouldValidate) {
           return target.merge(ctx, { triggered: true })
         }
     
@@ -380,7 +380,7 @@ export function reatomField<State, Value = State>(
           ).catch(noop)
     
           return target.merge(ctx, {
-            error: ctx.get(keepErrorDuringValidating.value) ? validationValue.error : undefined,
+            error: ctx.get(fieldOptions.value).keepErrorDuringValidating ? validationValue.error : undefined,
             meta: undefined,
             triggered: true,
             validating: true,
@@ -407,11 +407,15 @@ export function reatomField<State, Value = State>(
     }))
   )
 
-  validation.__reatom.initState = ctx => ctx.get(shouldValidate.value) ? fieldInitValidation : fieldInitValidationLess
+  validation.__reatom.initState = ctx => (
+    ctx.get(fieldOptions.value).shouldValidate 
+      ? fieldInitValidation 
+      : fieldInitValidationLess
+  )
 
   // @ts-expect-error the original computed state can't be typed properly
   validation.__reatom.computer = (ctx, state: FieldValidation) => {
-    if (!ctx.spy(shouldValidate.value))
+    if (!ctx.spy(fieldOptions.value).shouldValidate)
 			return fieldInitValidationLess
 
     if(ctx.spy(disabled))
@@ -448,11 +452,7 @@ export function reatomField<State, Value = State>(
     validation,
     value,
     disabled,
-    keepErrorDuringValidating,
-    keepErrorOnChange,
-    validateOnChange,
-    validateOnBlur,
-    shouldValidate,
+    options: fieldOptions,
 
     __reatomField: true as const
   })

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -1,9 +1,10 @@
 import { type Action, type Atom, type AtomMut, AtomState, type Ctx, CtxSpy, __count, action, atom } from '@reatom/core'
-import { __thenReatomed, abortCauseContext, isCausedBy, withAbortableSchedule } from '@reatom/effects'
+import { __thenReatomed, abortCauseContext, getTopController, isCausedBy, withAbortableSchedule } from '@reatom/effects'
 import { BooleanAtom, type RecordAtom, reatomBoolean, reatomRecord, withAssign } from '@reatom/primitives'
 import { isDeepEqual, noop, toAbortError } from '@reatom/utils'
 
 import { toError } from './utils'
+import { AsyncCtx } from '@reatom/async'
 
 export interface FieldFocus {
   /** The field is focused. */
@@ -46,6 +47,10 @@ export interface ValidationAtom extends Atom<FieldValidation> {
   setError: Action<[error: string], FieldValidation>
 }
 
+export interface FieldElementRef {
+  focus: (options?: { preventScroll?: boolean }) => void;
+}
+
 export interface FieldLikeAtom<State = any> extends AtomMut<State> {
   __reatomField: true
 }
@@ -71,6 +76,9 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
 
   /** Atom that defines if the field is disabled */
   disabled: BooleanAtom
+
+  /** Atom with the reference to the field element. */
+  elementRef: AtomMut<FieldElementRef | undefined>;
 
   options: RecordAtom<{
     /**
@@ -104,7 +112,7 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
 }
 
 export type FieldValidateOption<State = any, Value = State> = (
-  ctx: Ctx,
+  ctx: AsyncCtx,
   meta: {
     state: State
     value: Value
@@ -158,6 +166,11 @@ export interface FieldOptions<State = any, Value = State> {
    * @default false
    */
   disabled?: boolean
+
+  /**
+   * Defines a default element reference accosiated with the field.
+   */
+  elementRef?: FieldElementRef;
 
   /**
    * Defines the reset behavior of the validation state during async validation.
@@ -269,6 +282,8 @@ export function reatomField<State, Value = State>(
       validation.trigger(ctx)
   })
 
+  const elementRef = atom(restOptions.elementRef, `${name}.elementRef`)
+
   const field = stateAtom ?? atom(_initState, `${name}.field`)
   const initState = atom(_initState, `${name}.initState`)
   // TODO: make sure it's ok to copy initState of other atom. 
@@ -345,7 +360,9 @@ export function reatomField<State, Value = State>(
     
         try {
           contract?.(state)
-          promise = validateFn?.(withAbortableSchedule(ctx), {
+          const asyncCtx = Object.assign(withAbortableSchedule(ctx), { controller });
+          
+          promise = validateFn?.(asyncCtx, {
             state,
             value: valueValue,
             focus: focusValue,
@@ -452,6 +469,7 @@ export function reatomField<State, Value = State>(
     validation,
     value,
     disabled,
+    elementRef,
     options: fieldOptions,
 
     __reatomField: true as const

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -1,6 +1,6 @@
 import { type Action, type Atom, type AtomMut, AtomState, type Ctx, CtxSpy, __count, action, atom } from '@reatom/core'
 import { __thenReatomed, abortCauseContext, isCausedBy, withAbortableSchedule } from '@reatom/effects'
-import { type RecordAtom, reatomRecord } from '@reatom/primitives'
+import { BooleanAtom, type RecordAtom, reatomBoolean, reatomRecord, withAssign } from '@reatom/primitives'
 import { isDeepEqual, noop, toAbortError } from '@reatom/utils'
 
 import { toError } from './utils'
@@ -30,7 +30,7 @@ export interface FieldValidation {
   validating: boolean
 }
 
-export interface FocusAtom extends RecordAtom<FieldFocus> {
+export interface FocusAtom extends Atom<FieldFocus> {
   /** Action for handling field focus. */
   in: Action<[], void>
 
@@ -38,9 +38,12 @@ export interface FocusAtom extends RecordAtom<FieldFocus> {
   out: Action<[], void>
 }
 
-export interface ValidationAtom extends RecordAtom<FieldValidation> {
+export interface ValidationAtom extends Atom<FieldValidation> {
   /** Action to trigger field validation. */
   trigger: Action<[], FieldValidation>
+
+  /** Action to set an error for the field */
+  setError: Action<[error: string], FieldValidation>
 }
 
 export interface FieldLikeAtom<State = any> extends AtomMut<State> {
@@ -66,39 +69,36 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
   /** Atom with the "value" data, computed by the `fromState` option */
   value: Atom<Value>
 
+  /** Atom that defines if the field is disabled */
+  disabled: BooleanAtom
+
   /**
    * Defines the reset behavior of the validation state during async validation.
    * @default false
    */
-  keepErrorDuringValidating: Atom<boolean>
+  keepErrorDuringValidating: AtomMut<boolean | undefined>
 
   /**
    * Defines the reset behavior of the validation state on field change.
    * Useful if the validation is triggered on blur or submit only.
    * @default !validateOnChange
    */
-  keepErrorOnChange: Atom<boolean>
+  keepErrorOnChange: AtomMut<boolean | undefined>
 
   /**
    * Defines if the validation should be triggered with every field change.
    * @default false
    */
-  validateOnChange: Atom<boolean>
+  validateOnChange: AtomMut<boolean | undefined>
 
   /**
    * Defines if the validation should be triggered on the field blur.
    * @default false
    */
-  validateOnBlur: Atom<boolean>
+  validateOnBlur: AtomMut<boolean | undefined>
 
-	/** @internal @deprecated */
-	__defaults: {
-		keepErrorDuringValidating?: boolean
-		keepErrorOnChange?: boolean
-		validateOnChange?: boolean
-		validateOnBlur?: boolean
-		shouldValidate?: boolean
-	};
+  /* @internal */
+  shouldValidate: AtomMut<boolean | undefined>
 }
 
 export type FieldValidateOption<State = any, Value = State> = (
@@ -152,6 +152,12 @@ export interface FieldOptions<State = any, Value = State> {
   contract?: (state: State) => unknown
 
   /**
+   * Defines if the field is disabled by default.
+   * @default false
+   */
+  disabled?: boolean
+
+  /**
    * Defines the reset behavior of the validation state during async validation.
    * @default false
    */
@@ -197,11 +203,23 @@ export const fieldInitValidationLess: FieldValidation = {
   validating: false,
 }
 
-export const reatomField = <State, Value = State>(
+export function reatomField<State, Value = State>(
+  _initState: State,
+  options: string | FieldOptions<State, Value>,
+): FieldAtom<State, Value>;
+
+/** @internal */
+export function reatomField<State, A extends AtomMut<State>, Value = State>(
+  _initState: State,
+  options: string | FieldOptions<State, Value>,
+  stateAtom: A
+): A & FieldAtom<State, Value>;
+
+export function reatomField<State, Value = State>(
   _initState: State,
   options: string | FieldOptions<State, Value> = {},
-  _stateAtom?: AtomMut<State>
-): FieldAtom<State, Value> => {
+  stateAtom?: AtomMut<State>
+): FieldAtom<State, Value> {
   interface This extends FieldAtom<State, Value> { }
 
   const {
@@ -215,141 +233,198 @@ export const reatomField = <State, Value = State>(
     ...restOptions
   } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
 
-	const reactiveOptions = Object.assign(restOptions, { shouldValidate: undefined })
+	const validateOnBlur = atom(restOptions.validateOnBlur, `${name}.validateOnBlur`).pipe(
+    withAssign((target, name) => ({
+      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
+    }))
+  )
 
-	const validateOnBlur = atom(false, `${name}.validateOnBlur`)
-  validateOnBlur.__reatom.initState = () => reactiveOptions.validateOnBlur ?? false
+	const validateOnChange = atom(restOptions.validateOnChange, `${name}.validateOnChange`).pipe(
+    withAssign((target, name) => ({
+      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
+    }))
+  )
 
-	const validateOnChange = atom(false, `${name}.validateOnChange`)
-  validateOnChange.__reatom.initState = () => reactiveOptions.validateOnChange ?? false
+	const keepErrorDuringValidating = atom(restOptions.keepErrorDuringValidating, `${name}.keepErrorDuringValidating`).pipe(
+    withAssign((target, name) => ({
+      value: atom((ctx) => ctx.spy(target) ?? false, `${name}.value`)
+    }))
+  )
 
-	const keepErrorDuringValidating = atom(false, `${name}.keepErrorDuringValidating`)
-  keepErrorDuringValidating.__reatom.initState = () => reactiveOptions.keepErrorDuringValidating ?? false
+	const keepErrorOnChange = atom(restOptions.keepErrorOnChange, `${name}.keepErrorOnChange`).pipe(
+    withAssign((target, name) => ({
+      value: atom((ctx) => ctx.spy(target) ?? !ctx.spy(validateOnChange.value), `${name}.value`)
+    }))
+  )
 
-	const keepErrorOnChange = atom(false, `${name}.keepErrorOnChange`)
-  keepErrorOnChange.__reatom.initState = (ctx) => reactiveOptions.keepErrorOnChange ?? !ctx.get(validateOnChange)
+	const shouldValidate = atom<boolean | undefined>(undefined, `${name}.shouldValidate`).pipe(
+    withAssign((target, name) => ({
+      value: atom((ctx) => ctx.spy(target) ?? !!(validateFn || contract), `${name}.value`)
+    }))
+  )
 
-	const shouldValidate = atom(false, `${name}.shouldValidate`)
-  shouldValidate.__reatom.initState = () => reactiveOptions.shouldValidate ?? !!(validateFn || contract)
+  const disabled = reatomBoolean(restOptions.disabled ?? false, `${name}.disabled`)
+  disabled.onChange((ctx, status) => {
+    if(!status)
+      validation.trigger(ctx)
+  })
 
-  const field = _stateAtom ?? atom(_initState, `${name}.field`)
+  const field = stateAtom ?? atom(_initState, `${name}.field`)
   const initState = atom(_initState, `${name}.initState`)
   // TODO: make sure it's ok to copy initState of other atom. 
   // We need to extract initial state from `field` atom here and pass it to `initState` atom
   initState.__reatom.initState = field.__reatom.initState
-  
+
+	field.onChange((ctx) => {
+    if(isCausedBy(ctx, reset))
+      return;
+
+		ctx.get(validationController).abort(toAbortError('change'))
+
+    validation.merge(ctx,
+      ctx.get(keepErrorOnChange.value)
+        ? { validating: false, triggered: false }
+        : { validating: false, triggered: false, error: undefined }
+    )
+
+    if (!ctx.get(disabled) && ctx.get(validateOnChange.value))
+			validation.trigger(ctx)
+	})
+
   const value: This['value'] = atom((ctx) => fromState(ctx, ctx.spy(field)), `${name}.value`)
 
-  const focus = reatomRecord(fieldInitFocus, `${name}.focus`) as This['focus']
+  const focus = reatomRecord(fieldInitFocus, `${name}.focus`).pipe(
+    withAssign((target, name) => ({
+      in: action((ctx) => {
+        focus.merge(ctx, { active: true })
+      }, `${name}.in`),
+      out: action((ctx) => {
+        focus.merge(ctx, { active: false, touched: true })
+      }, `${name}.out`)
+    }))
+  )
+
   // @ts-expect-error the original computed state can't be typed properly
   focus.__reatom.computer = (ctx, state: FieldFocus) => {
     const dirty = isDirty(ctx, ctx.spy(value), fromState(ctx, ctx.spy(initState)))
     return state.dirty === dirty ? state : { ...state, dirty }
   }
 
-  focus.in = action((ctx) => {
-    focus.merge(ctx, { active: true })
-  }, `${name}.focus.in`)
-
-  focus.out = action((ctx) => {
-    focus.merge(ctx, { active: false, touched: true })
-  }, `${name}.focus.out`)
-
-  const validation = reatomRecord(
-    fieldInitValidationLess,
-    `${name}.validation`,
-  ) as This['validation']
-
-  validation.__reatom.initState = ctx => ctx.get(shouldValidate) ? fieldInitValidation : fieldInitValidationLess
-
-  // @ts-expect-error the original computed state can't be typed properly
-  validation.__reatom.computer = (ctx, state: FieldValidation) => {
-    if (!ctx.spy(shouldValidate))
-			return state
-
-    ctx.spy(value)
-    return state.triggered ? { ...state, triggered: false } : state
-  }
+  focus.out.onCall((ctx) => {
+		if (!ctx.get(disabled) && ctx.get(validateOnBlur.value))
+			validation.trigger(ctx)
+	})
 
   const validationController = atom(new AbortController(), `${name}._validationController`)
   // prevent collisions for different contexts
   validationController.__reatom.initState = () => new AbortController()
 
-  validation.trigger = action((ctx) => {
-    const validationValue = ctx.get(validation)
-
-    if (validationValue.triggered) return validationValue
-    if (!ctx.get(shouldValidate)) {
-      return validation.merge(ctx, { triggered: true })
-    }
-
-    ctx.get(validationController).abort(toAbortError('concurrent'))
-
-    const controller = validationController(ctx, new AbortController())
-    abortCauseContext.set(ctx.cause, controller)
-
-    const state = ctx.get(field)
-    const valueValue = ctx.get(value)
-    const focusValue = ctx.get(focus)
-    let promise: any
-    let message: undefined | string
-
-    try {
-      contract?.(state)
-      promise = validateFn?.(withAbortableSchedule(ctx), {
-        state,
-        value: valueValue,
-        focus: focusValue,
-        validation: validationValue,
-      })
-    } catch (error) {
-      message = toError(error)
-    }
-
-    if (promise instanceof Promise) {
-      __thenReatomed(
-        ctx,
-        promise,
-        () => {
-          if (controller.signal.aborted) return
-          validation.merge(ctx, {
-            error: undefined,
+  const validation = reatomRecord(
+    fieldInitValidationLess,
+    `${name}.validation`,
+  ).pipe(
+    withAssign((target, name) => ({
+      trigger: action((ctx) => {
+        const validationValue = ctx.get(target)
+    
+        if (validationValue.triggered) return validationValue
+        if (!ctx.get(shouldValidate.value)) {
+          return target.merge(ctx, { triggered: true })
+        }
+    
+        ctx.get(validationController).abort(toAbortError('concurrent'))
+    
+        const controller = validationController(ctx, new AbortController())
+        abortCauseContext.set(ctx.cause, controller)
+    
+        const state = ctx.get(field)
+        const valueValue = ctx.get(value)
+        const focusValue = ctx.get(focus)
+        let promise: any
+        let message: undefined | string
+    
+        try {
+          contract?.(state)
+          promise = validateFn?.(withAbortableSchedule(ctx), {
+            state,
+            value: valueValue,
+            focus: focusValue,
+            validation: validationValue,
+          })
+        } catch (error) {
+          message = toError(error)
+        }
+    
+        if (promise instanceof Promise) {
+          __thenReatomed(
+            ctx,
+            promise,
+            () => {
+              if (controller.signal.aborted) return
+              target.merge(ctx, {
+                error: undefined,
+                meta: undefined,
+                triggered: true,
+                validating: false,
+              })
+            },
+            (error) => {
+              if (controller.signal.aborted) return
+              target.merge(ctx, {
+                error: toError(error),
+                meta: undefined,
+                triggered: true,
+                validating: false,
+              })
+            },
+          ).catch(noop)
+    
+          return target.merge(ctx, {
+            error: ctx.get(keepErrorDuringValidating.value) ? validationValue.error : undefined,
             meta: undefined,
             triggered: true,
-            validating: false,
+            validating: true,
           })
-        },
-        (error) => {
-          if (controller.signal.aborted) return
-          validation.merge(ctx, {
-            error: toError(error),
-            meta: undefined,
-            triggered: true,
-            validating: false,
-          })
-        },
-      ).catch(noop)
+        }
+    
+        return target.merge(ctx, {
+          validating: false,
+          error: message,
+          meta: undefined,
+          triggered: true,
+        })
+      }, `${name}.trigger`),
+      setError: action((ctx, error: string) => {
+        ctx.get(validationController).abort(toAbortError('setError'))
 
-      return validation.merge(ctx, {
-        error: ctx.get(keepErrorDuringValidating) ? validationValue.error : undefined,
-        meta: undefined,
-        triggered: true,
-        validating: true,
-      })
-    }
+        return target.merge(ctx, {
+          error,
+          meta: undefined,
+          triggered: true,
+          validating: false,
+        });
+      }, `${name}.setError`),
+    }))
+  )
 
-    return validation.merge(ctx, {
-      validating: false,
-      error: message,
-      meta: undefined,
-      triggered: true,
-    })
-  }, `${name}.validation.trigger`)
+  validation.__reatom.initState = ctx => ctx.get(shouldValidate.value) ? fieldInitValidation : fieldInitValidationLess
+
+  // @ts-expect-error the original computed state can't be typed properly
+  validation.__reatom.computer = (ctx, state: FieldValidation) => {
+    if (!ctx.spy(shouldValidate.value))
+			return fieldInitValidationLess
+
+    if(ctx.spy(disabled))
+      return fieldInitValidation
+
+    ctx.spy(value)
+    return state.triggered ? { ...state, triggered: false } : state
+  }
 
   const change: This['change'] = action((ctx, newValue) => {
     const prevValue = ctx.get(value)
-
-    if (!filter(ctx, newValue, prevValue)) return prevValue
+    if (!filter(ctx, newValue, prevValue)) 
+      return prevValue
 
     field(ctx, toState(ctx, newValue))
     focus.merge(ctx, { touched: true })
@@ -360,27 +435,10 @@ export const reatomField = <State, Value = State>(
   const reset: This['reset'] = action((ctx) => {
     field(ctx, ctx.get(initState))
     focus(ctx, fieldInitFocus)
+
     validation(ctx, fieldInitValidation)
     ctx.get(validationController).abort(toAbortError('reset'))
   }, `${name}.reset`)
-
-	field.onChange((ctx) => {
-		if (ctx.get(keepErrorOnChange))
-			return
-
-		validation(ctx, fieldInitValidation)
-		ctx.get(validationController).abort(toAbortError('change'))
-	})
-
-	field.onChange((ctx) => {
-		if (ctx.get(validateOnChange) && !isCausedBy(ctx, reset))
-			validation.trigger(ctx)
-	})
-
-	focus.out.onCall((ctx) => {
-		if (ctx.get(validateOnBlur))
-			validation.trigger(ctx)
-	})
 
   return Object.assign(field, {
     change,
@@ -389,11 +447,13 @@ export const reatomField = <State, Value = State>(
     reset,
     validation,
     value,
+    disabled,
     keepErrorDuringValidating,
     keepErrorOnChange,
     validateOnChange,
     validateOnBlur,
-    __defaults: reactiveOptions,
+    shouldValidate,
+
     __reatomField: true as const
   })
 }
@@ -401,10 +461,7 @@ export const reatomField = <State, Value = State>(
 export const withField = <T extends AtomMut, Value = AtomState<T>>(
   options: Omit<FieldOptions<AtomState<T>, Value>, 'name'> = {}
 ): ((anAtom: T) => T & FieldAtom<AtomState<T>, Value>) => {
-  return (anAtom: T) => Object.assign(
-    anAtom,
-    reatomField(null as AtomState<T>, { name: anAtom.__reatom.name, ...options }, anAtom)
-  );
+  return (anAtom: T) =>  reatomField(null as AtomState<T>, { name: anAtom.__reatom.name, ...options }, anAtom)
 }
 
 export const isFieldAtom = (thing: any): thing is FieldLikeAtom => thing?.__reatomField === true

--- a/packages/form/src/reatomField.ts
+++ b/packages/form/src/reatomField.ts
@@ -1,5 +1,5 @@
 import { type Action, type Atom, type AtomMut, AtomState, type Ctx, CtxSpy, __count, action, atom } from '@reatom/core'
-import { __thenReatomed, abortCauseContext, withAbortableSchedule } from '@reatom/effects'
+import { __thenReatomed, abortCauseContext, isCausedBy, withAbortableSchedule } from '@reatom/effects'
 import { type RecordAtom, reatomRecord } from '@reatom/primitives'
 import { isDeepEqual, noop, toAbortError } from '@reatom/utils'
 
@@ -65,6 +65,31 @@ export interface FieldAtom<State = any, Value = State> extends FieldLikeAtom<Sta
 
   /** Atom with the "value" data, computed by the `fromState` option */
   value: Atom<Value>
+
+  /**
+   * Defines the reset behavior of the validation state during async validation.
+   * @default false
+   */
+  keepErrorDuringValidating: Atom<boolean>
+
+  /**
+   * Defines the reset behavior of the validation state on field change.
+   * Useful if the validation is triggered on blur or submit only.
+   * @default !validateOnChange
+   */
+  keepErrorOnChange: Atom<boolean>
+
+  /**
+   * Defines if the validation should be triggered with every field change.
+   * @default false
+   */
+  validateOnChange: Atom<boolean>
+
+  /**
+   * Defines if the validation should be triggered on the field blur.
+   * @default false
+   */
+  validateOnBlur: Atom<boolean>
 
 	/** @internal */
 	__defaults: {
@@ -190,7 +215,7 @@ export const reatomField = <State, Value = State>(
     ...restOptions
   } = typeof options === 'string' ? ({ name: options } as FieldOptions<State, Value>) : options
 
-	const reactiveOptions = Object.assign(restOptions, { shouldValidate: false })
+	const reactiveOptions = Object.assign(restOptions, { shouldValidate: undefined })
 
 	const validateOnBlur = atom(false, `${name}.validateOnBlur`)
   validateOnBlur.__reatom.initState = () => reactiveOptions.validateOnBlur ?? false
@@ -346,7 +371,7 @@ export const reatomField = <State, Value = State>(
 	})
 
 	field.onChange((ctx) => {
-		if (ctx.get(validateOnChange))
+		if (ctx.get(validateOnChange) && !isCausedBy(ctx, reset))
 			validation.trigger(ctx)
 	})
 
@@ -362,6 +387,10 @@ export const reatomField = <State, Value = State>(
     reset,
     validation,
     value,
+    keepErrorDuringValidating,
+    keepErrorOnChange,
+    validateOnChange,
+    validateOnBlur,
     __defaults: reactiveOptions,
     __reatomField: true as const
   })

--- a/packages/form/src/reatomFieldSet.ts
+++ b/packages/form/src/reatomFieldSet.ts
@@ -1,0 +1,167 @@
+import { CtxSpy, isAtom, type Atom, type Action, __count, atom, action, type Ctx, type Rec } from '@reatom/core';
+import { parseAtoms } from '@reatom/lens';
+import { isLinkedListAtom } from '@reatom/primitives';
+import { entries, isShallowEqual, isObject } from '@reatom/utils';
+import { type FieldAtom, type FieldFocus, type FieldValidation, fieldInitFocus, fieldInitValidation } from './reatomField';
+import { FormInitState, FormFields, FormFieldElement, FormFieldArrayAtom, FormState, FormPartialState } from './reatomForm';
+
+export interface FieldSet<T extends FormInitState> {
+  /** Fields from the init state */
+  fields: FormFields<T>;
+
+  /** Computed list of all the fields from the fields tree */
+  fieldsList: Atom<FieldAtom[]>;
+
+  /** Computed list of all the field arrays from the fields tree */
+  fieldArraysList: Atom<FormFieldArrayAtom[]>;
+
+  /** Atom with the state of the fieldset, computed from all the fields in `fieldsList` */
+  fieldsState: Atom<FormState<T>>;
+
+  /** Atom with focus state of the fieldset, computed from all the fields in `fieldsList` */
+  focus: Atom<FieldFocus>;
+
+  /** Atom with validation state of the fieldset, computed from all the fields in `fieldsList` */
+  validation: Atom<FieldValidation>;
+
+  /** Action to set initial values for each field or field array in the fieldset */
+  init: Action<[initState: FormPartialState<T>], void>;
+
+  /** Action to reset the state, the value, the validation, and the focus states. */
+  reset: Action<[initState?: FormPartialState<T>], void>;
+}
+
+export const reatomFieldsSet = <T extends FormInitState>(
+  fields: FormFields<T>,
+  name = __count('fieldsSet')
+): FieldSet<T> => {
+  const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
+  const fieldArraysList = atom(ctx => computeFieldArraysList(ctx, fields), `${name}.fieldArraysList`);
+  const fieldsState = atom(ctx => parseAtoms(ctx, fields), `${name}.fieldsState`);
+  
+  const focus = atom((ctx, state = fieldInitFocus) => {
+    const focus = { ...fieldInitFocus };
+
+    for (const field of ctx.spy(fieldsList)) {
+      if (ctx.spy(field.disabled))
+        continue;
+
+      const { active, dirty, touched } = ctx.spy(field.focus);
+      focus.active ||= active;
+      focus.dirty ||= dirty;
+      focus.touched ||= touched;
+    }
+
+    return isShallowEqual(focus, state) ? state : focus;
+  }, `${name}.focus`);
+
+  const validation = atom((ctx, state = fieldInitValidation) => {
+    const validation = { ...fieldInitValidation };
+    validation.triggered = true;
+
+    for (const field of ctx.spy(fieldsList)) {
+      if (ctx.spy(field.disabled))
+        continue;
+
+      const { triggered, validating, error } = ctx.spy(field.validation);
+
+      validation.triggered &&= triggered;
+      validation.validating ||= validating;
+      validation.error ||= error;
+    }
+
+    return isShallowEqual(validation, state) ? state : validation;
+  }, `${name}.validation`);
+
+  const reinitState = (ctx: Ctx, initState: FormPartialState<T>, fields: FormFields) => {
+    for (const [key, value] of Object.entries(initState as Rec)) {
+      if (isLinkedListAtom(fields[key])) {
+        // @ts-expect-error bad type for initiate
+        fields[key].initState(ctx, fields[key].initiate(ctx, value.map(v => [v])));
+      }
+      else if (isObject(value) &&
+        !(value instanceof Date) &&
+        key in fields &&
+        !isAtom(fields[key])) {
+        reinitState(ctx, value, fields[key] as unknown as FormFields);
+      }
+      else if (isAtom(fields[key])) {
+        fields[key].initState(ctx, value);
+      }
+    }
+  };
+
+  const init = action((ctx, initState: FormPartialState<T>) => {
+    reinitState(ctx, initState, fields);
+  }, `${name}.init`);
+
+  const reset = action((ctx, initState?: FormPartialState<T>) => {
+    if (initState)
+      reinitState(ctx, initState, fields);
+
+    ctx.get(fieldArraysList).forEach((fieldArray) => fieldArray.reset(ctx));
+    ctx.get(fieldsList).forEach((fieldAtom) => fieldAtom.reset(ctx));
+  }, `${name}.reset`);
+
+  return {
+    fieldsList,
+    fieldArraysList,
+    fields,
+    fieldsState,
+    focus,
+    validation,
+    init,
+    reset
+  };
+};
+
+const computeFieldsList = <T extends FormInitState>(
+  ctx: CtxSpy,
+  fields: FormFields<T>,
+  acc: Array<FieldAtom> = []
+): Array<FieldAtom> => {
+  const computeElement = (
+    element: FormFieldElement,
+    acc: Array<FieldAtom> = []
+  ) => {
+    if (isLinkedListAtom(element)) {
+      const elements = ctx.spy(element.array);
+      elements.forEach(e => computeElement(e, acc));
+    }
+    else if (isAtom(element)) acc.push(element);
+    else computeFieldsList(ctx, element, acc);
+
+    return acc;
+  };
+
+  for (const [_, field] of entries(fields))
+    acc.push(...computeElement(field));
+
+  return acc;
+};
+
+const computeFieldArraysList = <T extends FormInitState>(
+  ctx: CtxSpy,
+  fields: FormFields<T>,
+  acc: Array<FormFieldArrayAtom<unknown>> = []
+) => {
+  const computeElement = (
+    element: FormFieldElement,
+    acc: Array<FormFieldArrayAtom<unknown>> = []
+  ) => {
+    if (isLinkedListAtom(element)) {
+      acc.push(element as FormFieldArrayAtom<unknown>);
+      ctx.spy(element.array).forEach(e => computeElement(e, acc));
+    }
+    else if (!isAtom(element))
+      computeFieldArraysList(ctx, element, acc);
+
+    return acc;
+  };
+
+  for (const [_, field] of entries(fields)) {
+    acc.push(...computeElement(field));
+  }
+
+  return acc;
+};

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,132 +1,176 @@
 import { test, expect } from 'vitest'
 import { createCtx } from '@reatom/core'
-import { reatomForm } from '.'
+import { FieldAtom, reatomField, reatomForm } from '.'
+import { reatomArray, reatomSet } from '@reatom/primitives';
 
-test(`adding and removing fields`, async () => {  
-  const ctx = createCtx();
-  const form = reatomForm({ name: 'testForm', onSubmit: () => {} });
-  const field = form.reatomField('', 'fieldAtom');
-  expect(ctx.get(form.fieldsList).length).toBe(0);
+test(`adding and removing fields`, async () => {
+	const ctx = createCtx();
+	const form = reatomForm({
+		field: reatomField('initial', 'fieldAtom'),
+		list: reatomArray([
+			reatomField('initial', 'fieldAtom')
+		], 'listAtom'),
+	}, {
+		name: 'testForm',
+		onSubmit: () => { }
+	});
 
-  field.change(ctx, 'value');
-  expect(ctx.get(form.fieldsList).length).toBe(1);
+	expect(ctx.get(form.fields.field)).toBe('initial');
+	expect(ctx.get(form.fields.list).length).toBe(1);
 
-  field.remove(ctx);  
-  expect(ctx.get(form.fieldsList).length).toBe(0);
+	form.fields.list(ctx, list => [...list, reatomField('initial', 'fieldAtom')]);
+	expect(ctx.get(form.fields.list).length).toBe(2);
+
+	form.fields.list(ctx, []);
+	expect(ctx.get(form.fields.list).length).toBe(0);
 })
 
 test('focus states', () => {
-  const ctx = createCtx()
-  const form = reatomForm({ name: 'testForm', onSubmit: () => {} })
-  const field1 = form.reatomField('', 'field1')
-  const field2 = form.reatomField('', 'field2')
+	const ctx = createCtx()
+	const form = reatomForm({
+		field1: { initState: '', validate: () => { } },
+		field2: { initState: '', validate: () => { } },
+		list: reatomArray([
+			reatomField('initial', 'fieldAtom')
+		], 'listAtom')
+	}, {
+		name: 'testForm',
+		onSubmit: () => { }
+	})
 
-  field1.change(ctx, 'value')
-  field2.change(ctx, 'value')
+	form.fields.field1.change(ctx, 'value')
+	form.fields.field2.change(ctx, 'value')
 
-  expect(ctx.get(form.focus)).toEqual({
-    active: false,
-    dirty: true,
-    touched: true,
-  })
+	expect(ctx.get(form.focus)).toEqual({
+		active: false,
+		dirty: true,
+		touched: true,
+	})
 
-  field1.focus.in(ctx)
-  expect(ctx.get(form.focus).active).toBe(true)
+	form.fields.field1.focus.in(ctx)
+	expect(ctx.get(form.focus).active).toBe(true)
 
-  field1.focus.out(ctx)
-  expect(ctx.get(form.focus).active).toBe(false)
-  expect(ctx.get(form.focus).touched).toBe(true)
+	form.fields.field1.focus.out(ctx)
+	expect(ctx.get(form.focus).active).toBe(false)
+	expect(ctx.get(form.focus).touched).toBe(true)
+
+	form.reset(ctx);
+
+	const list = ctx.get(form.fields.list);
+	list[0]?.change(ctx, 'value');
+
+	expect(ctx.get(form.focus)).toEqual({
+		active: false,
+		dirty: true,
+		touched: true,
+	})
+
+	form.fields.list(ctx, []);
+
+	expect(ctx.get(form.focus)).toEqual({
+		active: false,
+		dirty: false,
+		touched: false,
+	})
 })
 
 test('validation states', async () => {
-  const ctx = createCtx()
+	const ctx = createCtx()
 
-  const form = reatomForm({
-    name: 'testForm',
-    onSubmit: () => {},
-    validate: () => {
-      throw new Error('Form validation error')
-    },
-  })
+	const contract = (value: string) => {
+		if (value === 'errorValue')
+			throw new Error('Contract error')
+	}
 
-  const contract = (value: string) => {
-    if(value === 'errorValue')
-      throw new Error('Contract error')
-  }
+	const form = reatomForm({
+		field1: { initState: '', contract, validateOnChange: true },
+		field2: { initState: '', contract, validateOnChange: true },
+		rest: reatomSet<FieldAtom<string>>(new Set)
+	}, {
+		name: 'testForm',
+		onSubmit: () => { },
+		validate: () => {
+			throw new Error('Form validation error')
+		},
+	})
 
-  const field1 = form.reatomField('', {
-    name: 'field1',
-    contract,
-    validateOnChange: true,
-  })
+	const { field1, field2, rest } = form.fields
 
-  const field2 = form.reatomField('', {
-    name: 'field2',
-    contract,
-    validateOnChange: true,
-  })
+	field1.change(ctx, 'value')
+	field2.change(ctx, 'value')
 
-  field1.change(ctx, 'value')
-  field2.change(ctx, 'value')
+	expect(ctx.get(form.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: true,
+		validating: false,
+	})
 
-  expect(ctx.get(form.validation)).toEqual({
-    error: undefined,
-    meta: undefined,
-    triggered: true,
-    validating: false,
-  })
+	field2.change(ctx, 'errorValue')
 
-  field2.change(ctx, 'errorValue')
+	expect(ctx.get(form.validation)).toEqual({
+		error: 'Contract error',
+		meta: undefined,
+		triggered: true,
+		validating: false,
+	})
 
-  expect(ctx.get(form.validation)).toEqual({
-    error: 'Contract error',
-    meta: undefined,
-    triggered: true,
-    validating: false,
-  })
+	field2.reset(ctx);
 
-  field2.reset(ctx);
+	await form.submit(ctx).catch(() => { })
+	expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
 
-  await form.submit(ctx).catch(() => {})
-  expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
+	const fieldNoValidationTrigger = reatomField('');
+	rest.add(ctx, fieldNoValidationTrigger);
 
-  const fieldNoValidationTrigger = form.reatomField('', {
-    name: 'field3',
-    contract,
-  });
+	fieldNoValidationTrigger.change(ctx, 'value');
 
-  fieldNoValidationTrigger.change(ctx, 'value');
+	expect(ctx.get(form.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: false,
+		validating: false,
+	})
 
-  expect(ctx.get(form.validation)).toEqual({
-    error: undefined,
-    meta: undefined,
-    triggered: false,
-    validating: false,
-  })
+	rest.clear(ctx);
+	field1.change(ctx, 'value')
+
+	expect(ctx.get(form.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: true,
+		validating: false,
+	})
 })
 
 test('reset', () => {
-  const ctx = createCtx()
-  const form = reatomForm({ name: 'testForm', onSubmit: () => {} })
-  const field = form.reatomField('initial', 'field')
+	const ctx = createCtx()
+	const form = reatomForm({
+		field: { initState: 'initial', validate: () => { } },
+	}, {
+		name: 'testForm',
+		onSubmit: () => { }
+	})
 
-  field.change(ctx, 'value')
-  field.focus.in(ctx)
-  field.focus.out(ctx)
-  field.validation.trigger(ctx)
+	const { field } = form.fields;
 
-  form.reset(ctx)
+	field.change(ctx, 'value')
+	field.focus.in(ctx)
+	field.focus.out(ctx)
+	field.validation.trigger(ctx)
 
-  expect(ctx.get(field)).toBe('initial')
-  expect(ctx.get(field.focus)).toEqual({
-    active: false,
-    dirty: false,
-    touched: false,
-  })
-  expect(ctx.get(field.validation)).toEqual({
-    error: undefined,
-    meta: undefined,
-    triggered: false,
-    validating: false,
-  })
+	form.reset(ctx)
+
+	expect(ctx.get(field)).toBe('initial')
+	expect(ctx.get(field.focus)).toEqual({
+		active: false,
+		dirty: false,
+		touched: false,
+	})
+	expect(ctx.get(field.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: false,
+		validating: false,
+	})
 })

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,0 +1,132 @@
+import { test, expect } from 'vitest'
+import { createCtx } from '@reatom/core'
+import { reatomForm } from '.'
+
+test(`adding and removing fields`, async () => {  
+  const ctx = createCtx();
+  const form = reatomForm({ name: 'testForm', onSubmit: () => {} });
+  const field = form.reatomField('', 'fieldAtom');
+  expect(ctx.get(form.fieldsList).length).toBe(0);
+
+  field.change(ctx, 'value');
+  expect(ctx.get(form.fieldsList).length).toBe(1);
+
+  field.remove(ctx);  
+  expect(ctx.get(form.fieldsList).length).toBe(0);
+})
+
+test('focus states', () => {
+  const ctx = createCtx()
+  const form = reatomForm({ name: 'testForm', onSubmit: () => {} })
+  const field1 = form.reatomField('', 'field1')
+  const field2 = form.reatomField('', 'field2')
+
+  field1.change(ctx, 'value')
+  field2.change(ctx, 'value')
+
+  expect(ctx.get(form.focus)).toEqual({
+    active: false,
+    dirty: true,
+    touched: true,
+  })
+
+  field1.focus.in(ctx)
+  expect(ctx.get(form.focus).active).toBe(true)
+
+  field1.focus.out(ctx)
+  expect(ctx.get(form.focus).active).toBe(false)
+  expect(ctx.get(form.focus).touched).toBe(true)
+})
+
+test('validation states', async () => {
+  const ctx = createCtx()
+
+  const form = reatomForm({
+    name: 'testForm',
+    onSubmit: () => {},
+    validate: () => {
+      throw new Error('Form validation error')
+    },
+  })
+
+  const contract = (value: string) => {
+    if(value === 'errorValue')
+      throw new Error('Contract error')
+  }
+
+  const field1 = form.reatomField('', {
+    name: 'field1',
+    contract,
+    validateOnChange: true,
+  })
+
+  const field2 = form.reatomField('', {
+    name: 'field2',
+    contract,
+    validateOnChange: true,
+  })
+
+  field1.change(ctx, 'value')
+  field2.change(ctx, 'value')
+
+  expect(ctx.get(form.validation)).toEqual({
+    error: undefined,
+    meta: undefined,
+    triggered: true,
+    validating: false,
+  })
+
+  field2.change(ctx, 'errorValue')
+
+  expect(ctx.get(form.validation)).toEqual({
+    error: 'Contract error',
+    meta: undefined,
+    triggered: true,
+    validating: false,
+  })
+
+  field2.reset(ctx);
+
+  await form.submit(ctx).catch(() => {})
+  expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
+
+  const fieldNoValidationTrigger = form.reatomField('', {
+    name: 'field3',
+    contract,
+  });
+
+  fieldNoValidationTrigger.change(ctx, 'value');
+
+  expect(ctx.get(form.validation)).toEqual({
+    error: undefined,
+    meta: undefined,
+    triggered: false,
+    validating: false,
+  })
+})
+
+test('reset', () => {
+  const ctx = createCtx()
+  const form = reatomForm({ name: 'testForm', onSubmit: () => {} })
+  const field = form.reatomField('initial', 'field')
+
+  field.change(ctx, 'value')
+  field.focus.in(ctx)
+  field.focus.out(ctx)
+  field.validation.trigger(ctx)
+
+  form.reset(ctx)
+
+  expect(ctx.get(field)).toBe('initial')
+  expect(ctx.get(field.focus)).toEqual({
+    active: false,
+    dirty: false,
+    touched: false,
+  })
+  expect(ctx.get(field.validation)).toEqual({
+    error: undefined,
+    meta: undefined,
+    triggered: false,
+    validating: false,
+  })
+})

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { FieldAtom, reatomField, reatomForm } from '.'
 import { reatomArray, reatomSet } from '@reatom/primitives';
+import exp from 'constants';
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
@@ -128,7 +129,7 @@ test('validation states', async () => {
 	expect(ctx.get(form.validation)).toEqual({
 		error: undefined,
 		meta: undefined,
-		triggered: false,
+		triggered: true,
 		validating: false,
 	})
 
@@ -142,6 +143,41 @@ test('validation states', async () => {
 		validating: false,
 	})
 })
+
+test('default options for fields', async () => {
+	const ctx = createCtx()
+	const form = reatomForm({
+		field: { initState: 'initial', validate: () => { } },
+		array: ['one', 'two', 'free']
+	}, {
+		name: 'testForm',
+		validateOnChange: true,
+		onSubmit: () => { }
+	});
+
+	const { field, array } = form.fields;
+
+	field.change(ctx, 'value');
+
+	expect(ctx.get(field.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: true,
+		validating: false,
+	})
+
+	ctx.get(array.array).forEach(field => {
+		field.change(ctx, 'value');
+
+		expect(ctx.get(field.validation)).toEqual({
+			error: undefined,
+			meta: undefined,
+			triggered: true,
+			validating: false,
+		})
+	});
+})
+
 
 test('reset', () => {
 	const ctx = createCtx()

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -7,22 +7,22 @@ test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
 	const form = reatomForm({
 		field: reatomField('initial', 'fieldAtom'),
-		list: reatomArray([
+		list: [
 			reatomField('initial', 'fieldAtom')
-		], 'listAtom'),
+		],
 	}, {
 		name: 'testForm',
 		onSubmit: () => { }
 	});
 
 	expect(ctx.get(form.fields.field)).toBe('initial');
-	expect(ctx.get(form.fields.list).length).toBe(1);
+	expect(ctx.get(form.fields.list).size).toBe(1);
 
-	form.fields.list(ctx, list => [...list, reatomField('initial', 'fieldAtom')]);
-	expect(ctx.get(form.fields.list).length).toBe(2);
+	form.fields.list.create(ctx, reatomField('initial', 'fieldAtom'));
+	expect(ctx.get(form.fields.list).size).toBe(2);
 
-	form.fields.list(ctx, []);
-	expect(ctx.get(form.fields.list).length).toBe(0);
+	form.fields.list.clear(ctx);
+	expect(ctx.get(form.fields.list).size).toBe(0);
 })
 
 test('focus states', () => {
@@ -30,9 +30,9 @@ test('focus states', () => {
 	const form = reatomForm({
 		field1: { initState: '', validate: () => { } },
 		field2: { initState: '', validate: () => { } },
-		list: reatomArray([
+		list: [
 			reatomField('initial', 'fieldAtom')
-		], 'listAtom')
+		]
 	}, {
 		name: 'testForm',
 		onSubmit: () => { }
@@ -56,7 +56,7 @@ test('focus states', () => {
 
 	form.reset(ctx);
 
-	const list = ctx.get(form.fields.list);
+	const list = ctx.get(form.fields.list.array);
 	list[0]?.change(ctx, 'value');
 
 	expect(ctx.get(form.focus)).toEqual({
@@ -65,7 +65,7 @@ test('focus states', () => {
 		touched: true,
 	})
 
-	form.fields.list(ctx, []);
+	form.fields.list.clear(ctx);
 
 	expect(ctx.get(form.focus)).toEqual({
 		active: false,
@@ -85,7 +85,7 @@ test('validation states', async () => {
 	const form = reatomForm({
 		field1: { initState: '', contract, validateOnChange: true },
 		field2: { initState: '', contract, validateOnChange: true },
-		rest: reatomSet<FieldAtom<string>>(new Set)
+		rest: new Array<FieldAtom<string>>()
 	}, {
 		name: 'testForm',
 		onSubmit: () => { },
@@ -121,7 +121,7 @@ test('validation states', async () => {
 	expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
 
 	const fieldNoValidationTrigger = reatomField('');
-	rest.add(ctx, fieldNoValidationTrigger);
+	rest.create(ctx, fieldNoValidationTrigger);
 
 	fieldNoValidationTrigger.change(ctx, 'value');
 

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -286,3 +286,79 @@ test('reset', () => {
 		validating: false,
 	})
 })
+
+describe('init array with reset', () => {
+	test('flat fields with array', () => {
+		const ctx = createCtx()
+		const form = reatomForm({
+			dummy: 1,
+			list: [
+				{
+					kek: 'lel',
+					arr: ['1', '2']
+				}
+			]
+		})
+
+		form.reset(ctx, { list: [] })
+
+		expect(ctx.get(form.fields.list.array).length).toEqual(0)
+
+		form.fields.dummy.change(ctx, 2);
+
+		form.reset(ctx, { 
+			list: [
+				{ kek: 'lel', arr: ['1'] }
+			] 
+		})
+
+		expect(ctx.get(form.fields.list.array).length).toEqual(1)
+		expect(ctx.get(ctx.get(ctx.get(form.fields.list.array)[0]!.arr.array)[0]!.value)).toEqual('1')
+		expect(ctx.get(form.fields.dummy)).toEqual(1)
+	})
+
+	test('nested fields with array', () => {
+		const ctx = createCtx()
+
+		const form = reatomForm({
+			list: [
+				{
+					nestedList: [
+						{ number: '123', priority: Boolean(true) }
+					]
+				}
+			]
+		})
+
+		form.reset(ctx, {
+			list: [
+				{
+					nestedList: []
+				},
+				{
+					nestedList: [
+						{ number: '321', priority: false },
+						{ number: '456', priority: true }
+					]
+				}
+			]
+		})
+
+		const listArray = ctx.get(form.fields.list.array)
+		expect(listArray.length).toEqual(2)
+
+		const firstItemNestedList = ctx.get(listArray[0]!.nestedList.array)
+		expect(firstItemNestedList.length).toEqual(0)
+
+		const secondItemNestedList = ctx.get(listArray[1]!.nestedList.array)
+		expect(secondItemNestedList.length).toEqual(2)
+
+		const firstNestedItem = secondItemNestedList[0]!
+		expect(ctx.get(firstNestedItem.number)).toEqual('321')
+		expect(ctx.get(firstNestedItem.priority)).toEqual(false)
+
+		const secondNestedItem = secondItemNestedList[1]!
+		expect(ctx.get(secondNestedItem.number)).toEqual('456')
+		expect(ctx.get(secondNestedItem.priority)).toEqual(true)
+	})
+})

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,25 +1,21 @@
 import { test, expect } from 'vitest'
 import { createCtx } from '@reatom/core'
-import { FieldAtom, reatomField, reatomForm } from '.'
-import { reatomArray, reatomSet } from '@reatom/primitives';
-import exp from 'constants';
+import { reatomField, reatomForm } from '.'
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
-	const form = reatomForm({
+	const form = reatomForm(fieldArray => ({
 		field: reatomField('initial', 'fieldAtom'),
-		list: [
-			reatomField('initial', 'fieldAtom')
-		],
-	}, {
-		name: 'testForm',
-		onSubmit: () => { }
-	});
+		list: fieldArray({
+			initState: ['initial'],
+			create: (ctx, param) => reatomField(param, 'fieldAtom')
+		}),
+	}));
 
 	expect(ctx.get(form.fields.field)).toBe('initial');
 	expect(ctx.get(form.fields.list).size).toBe(1);
 
-	form.fields.list.create(ctx, reatomField('initial', 'fieldAtom'));
+	form.fields.list.create(ctx, 'initial');
 	expect(ctx.get(form.fields.list).size).toBe(2);
 
 	form.fields.list.clear(ctx);
@@ -28,16 +24,14 @@ test(`adding and removing fields`, async () => {
 
 test('focus states', () => {
 	const ctx = createCtx()
-	const form = reatomForm({
+	const form = reatomForm(fieldArray => ({
 		field1: { initState: '', validate: () => { } },
 		field2: { initState: '', validate: () => { } },
-		list: [
-			reatomField('initial', 'fieldAtom')
-		]
-	}, {
-		name: 'testForm',
-		onSubmit: () => { }
-	})
+		list: fieldArray({
+			initState: ['initial'],
+			create: (ctx, param) => reatomField(param, 'fieldAtom')
+		}),
+	}));
 
 	form.fields.field1.change(ctx, 'value')
 	form.fields.field2.change(ctx, 'value')
@@ -83,11 +77,11 @@ test('validation states', async () => {
 			throw new Error('Contract error')
 	}
 
-	const form = reatomForm({
+	const form = reatomForm(fieldArray => ({
 		field1: { initState: '', contract, validateOnChange: true },
 		field2: { initState: '', contract, validateOnChange: true },
-		rest: new Array<FieldAtom<string>>()
-	}, {
+		rest: fieldArray<string>([])
+	}), {
 		name: 'testForm',
 		onSubmit: () => { },
 		validate: () => {
@@ -121,9 +115,7 @@ test('validation states', async () => {
 	await form.submit(ctx).catch(() => { })
 	expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
 
-	const fieldNoValidationTrigger = reatomField('');
-	rest.create(ctx, fieldNoValidationTrigger);
-
+	const fieldNoValidationTrigger = rest.create(ctx, '');
 	fieldNoValidationTrigger.change(ctx, 'value');
 
 	expect(ctx.get(form.validation)).toEqual({
@@ -146,13 +138,11 @@ test('validation states', async () => {
 
 test('default options for fields', async () => {
 	const ctx = createCtx()
-	const form = reatomForm({
+	const form = reatomForm(fieldArray => ({
 		field: { initState: 'initial', validate: () => { } },
-		array: ['one', 'two', 'free']
-	}, {
-		name: 'testForm',
-		validateOnChange: true,
-		onSubmit: () => { }
+		array: fieldArray(['one', 'two', 'free']),
+	}), {
+		validateOnChange: true
 	});
 
 	const { field, array } = form.fields;

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,9 +1,9 @@
-import { test, expect, describe } from 'vitest'
+import { test, expect, describe, vi } from 'vitest'
 import { createCtx, Ctx } from '@reatom/core'
 import { experimental_fieldArray, reatomField, reatomForm, withField } from '.'
 import { reatomBoolean } from '@reatom/primitives';
 import { z } from 'zod';
-import { sleep } from '@reatom/utils';
+import { noop, sleep } from '@reatom/utils';
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
@@ -528,4 +528,30 @@ test('concurrent field validation with schema', async () => {
 	await sleep();
 
 	expect(ctx.get(form.fields.age.validation).error).toBe('must be minimum 18');
+})
+
+test('autofocus recipe', async () => {
+	const ctx = createCtx()
+
+	const form = reatomForm({
+		email: '',
+		age: 12
+	}, {
+		schema: z.object({
+			email: z.string().email(),
+			age: z.number().min(18),
+		})
+	})
+	const focusFn = vi.fn();
+	form.fields.email.elementRef(ctx, { focus: focusFn });
+
+	form.submit.onReject.onCall((ctx) => {
+		const errorField = ctx.get(form.fieldsList).find(field => !!ctx.get(field.validation).error);
+		if(errorField)
+			ctx.get(errorField.elementRef)?.focus();
+	})
+
+	await form.submit(ctx).catch(noop);
+	expect(ctx.get(form.submit.error)).toBeInstanceOf(Error);
+	expect(focusFn).toBeCalled();
 })

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -239,7 +239,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 						initState: Array<{ number: string, priority: boolean }>(),
 						create: (ctx, { number, priority }) => ({
 							number,
-							priority: reatomBoolean(priority).pipe(withField(priority))
+							priority: reatomBoolean(priority).pipe(withField())
 						})
 					}),
 				}

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -363,6 +363,27 @@ describe('init array with reset', () => {
 		expect(ctx.get(secondNestedItem.priority)).toEqual(true)
 	})
 })
+
+test('form should correctly initialize field options', async () => {
+	const ctx = createCtx()
+
+	const form = reatomForm({
+		age: 12,
+		email: 'test',
+		fieldWithDefault: { initState: '', validateOnChange: false }
+	}, {
+		validateOnChange: true,
+		validateOnBlur: true,
+		keepErrorDuringValidating: true,
+		keepErrorOnChange: true,
+	})
+
+	expect(ctx.get(form.fields.age.validateOnChange)).toBe(true)
+	expect(ctx.get(form.fields.email.validateOnBlur)).toBe(true)
+	expect(ctx.get(form.fields.email.keepErrorDuringValidating)).toBe(true)
+	expect(ctx.get(form.fields.fieldWithDefault.keepErrorOnChange)).toBe(true)
+	expect(ctx.get(form.fields.fieldWithDefault.validateOnChange)).toBe(false)
+})
 	
 test('validating through form schema and placing errors to corresponding fields', async () => {
 	const ctx = createCtx()

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,14 +1,15 @@
 import { test, expect, describe } from 'vitest'
-import { createCtx } from '@reatom/core'
-import { fieldArray, reatomField, reatomForm, withField } from '.'
+import { createCtx, Ctx } from '@reatom/core'
+import { experimental_fieldArray, reatomField, reatomForm, withField } from '.'
 import { reatomBoolean } from '@reatom/primitives';
 import { z } from 'zod';
+import { sleep } from '@reatom/utils';
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
 	const form = reatomForm({
 		field: reatomField('initial', 'fieldAtom'),
-		list: fieldArray({
+		list: experimental_fieldArray({
 			initState: ['initial'],
 			create: (ctx, param) => reatomField(param, 'fieldAtom')
 		}),
@@ -29,7 +30,7 @@ test('focus states', () => {
 	const form = reatomForm({
 		field1: { initState: '', validate: () => { } },
 		field2: { initState: '', validate: () => { } },
-		list: fieldArray({
+		list: experimental_fieldArray({
 			initState: ['initial'],
 			create: (ctx, param) => reatomField(param, 'fieldAtom')
 		}),
@@ -79,10 +80,17 @@ test('validation states', async () => {
 			throw new Error('Contract error')
 	}
 
+	const validate = async (ctx: Ctx, { value }: { value: string }) => {
+		await sleep()
+		if (value === 'errorValue')
+			throw new Error('Contract error')
+	}
+
 	const form = reatomForm({
 		field1: { initState: '', contract, validateOnChange: true },
 		field2: { initState: '', contract, validateOnChange: true },
-		rest: fieldArray<string>([])
+		field3: { initState: '', validate, validateOnChange: true },
+		rest: experimental_fieldArray<string>([])
 	}, {
 		name: 'testForm',
 		onSubmit: () => { },
@@ -91,7 +99,7 @@ test('validation states', async () => {
 		},
 	})
 
-	const { field1, field2, rest } = form.fields
+	const { field1, field2, field3, rest } = form.fields
 
 	field1.change(ctx, 'value')
 	field2.change(ctx, 'value')
@@ -99,7 +107,7 @@ test('validation states', async () => {
 	expect(ctx.get(form.validation)).toEqual({
 		error: undefined,
 		meta: undefined,
-		triggered: true,
+		triggered: false,
 		validating: false,
 	})
 
@@ -108,14 +116,30 @@ test('validation states', async () => {
 	expect(ctx.get(form.validation)).toEqual({
 		error: 'Contract error',
 		meta: undefined,
-		triggered: true,
+		triggered: false,
 		validating: false,
+	})
+
+	field3.change(ctx, 'hey')
+
+	expect(ctx.get(form.validation)).toEqual({
+		error: 'Contract error',
+		meta: undefined,
+		triggered: true,
+		validating: true,
 	})
 
 	field2.reset(ctx);
 
 	await form.submit(ctx).catch(() => { })
 	expect(ctx.get(form.submit.error)?.message).toBe('Form validation error')
+
+	expect(ctx.get(form.validation)).toEqual({
+		error: undefined,
+		meta: undefined,
+		triggered: true,
+		validating: false,
+	})
 
 	const fieldNoValidationTrigger = rest.create(ctx, '');
 	fieldNoValidationTrigger.change(ctx, 'value');
@@ -138,11 +162,61 @@ test('validation states', async () => {
 	})
 })
 
+test('validation and focus states with disabled fields', async () => {
+	const ctx = createCtx()
+
+	const contract = (value: string) => {
+		if (value === 'errorValue')
+			throw new Error('Contract error')
+	}
+
+	const form = reatomForm({
+		field1: { initState: '', contract, validateOnChange: true },
+	}, 'testForm')
+
+	form.fields.field1.change(ctx, 'errorValue');
+	expect(ctx.get(form.validation)).toMatchObject({ error: 'Contract error', triggered: true });
+	expect(ctx.get(form.focus)).toMatchObject({ touched: true, dirty: true });
+
+	form.fields.field1.disabled(ctx, true);
+	expect(ctx.get(form.validation)).toMatchObject({ error: undefined, triggered: true });
+	expect(ctx.get(form.focus)).toMatchObject({ touched: false, dirty: false })
+
+	form.fields.field1.disabled(ctx, false);
+	expect(ctx.get(form.validation)).toMatchObject({ error: 'Contract error', triggered: true });
+	expect(ctx.get(form.focus)).toMatchObject({ touched: true, dirty: true });
+})
+
+test('validation states with disabled fields and defined schema', async () => {
+	const ctx = createCtx()
+
+	const formWithSchema = reatomForm({
+		field1: '',
+	}, {
+		validateOnChange: true,
+		schema: z.object({ 
+			field1: z.string().refine(value => value !== 'errorValue', 'Schema contract error') 
+		})
+	})
+
+	const targetField = formWithSchema.fields.field1;
+
+	targetField.change(ctx,'errorValue');
+	expect(ctx.get(formWithSchema.validation)).toMatchObject({ error: 'Schema contract error' });
+
+	targetField.change(ctx,'validValue');
+	expect(ctx.get(formWithSchema.validation)).toMatchObject({ error: undefined });
+
+	targetField.disabled(ctx,true);
+	targetField.change(ctx, 'errorValue');
+	expect(ctx.get(formWithSchema.validation)).toMatchObject({ error: undefined });
+})
+
 test('default options for fields', async () => {
 	const ctx = createCtx()
 	const form = reatomForm({
 		field: { initState: 'initial', validate: () => { } },
-		array: fieldArray(['one', 'two', 'free']),
+		array: experimental_fieldArray(['one', 'two', 'free']),
 	}, {
 		validateOnChange: true
 	});
@@ -197,7 +271,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 				{
 					array: ['hey'],
 					emptyArray: new Array<string>(),
-					emptyArrayExplicit: fieldArray<string>([])
+					emptyArrayExplicit: experimental_fieldArray<string>([])
 				}
 			]
 		})
@@ -235,7 +309,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 					street: '',
 					city: '',
 					tags: ['defaultTag', 'defaultTag2'],
-					phoneNumbers: fieldArray({
+					phoneNumbers: experimental_fieldArray({
 						initState: Array<{ number: string, priority: boolean }>(),
 						create: (ctx, { number, priority }) => ({
 							number,
@@ -378,11 +452,11 @@ test('form should correctly initialize field options', async () => {
 		keepErrorOnChange: true,
 	})
 
-	expect(ctx.get(form.fields.age.validateOnChange)).toBe(true)
-	expect(ctx.get(form.fields.email.validateOnBlur)).toBe(true)
-	expect(ctx.get(form.fields.email.keepErrorDuringValidating)).toBe(true)
-	expect(ctx.get(form.fields.fieldWithDefault.keepErrorOnChange)).toBe(true)
-	expect(ctx.get(form.fields.fieldWithDefault.validateOnChange)).toBe(false)
+	expect(ctx.get(form.fields.age.options).validateOnChange).toBe(true)
+	expect(ctx.get(form.fields.email.options).validateOnBlur).toBe(true)
+	expect(ctx.get(form.fields.email.options).keepErrorDuringValidating).toBe(true)
+	expect(ctx.get(form.fields.fieldWithDefault.options).keepErrorOnChange).toBe(true)
+	expect(ctx.get(form.fields.fieldWithDefault.options).validateOnChange).toBe(false)
 })
 	
 test('validating through form schema and placing errors to corresponding fields', async () => {
@@ -406,4 +480,52 @@ test('validating through form schema and placing errors to corresponding fields'
 	expect(ctx.get(form.fields.email.validation).error).toBeTruthy();
 	expect(ctx.get(ctx.get(form.fields.items.array)[0]!.validation).error).toBeTruthy();
 	expect(ctx.get(ctx.get(form.fields.items.array)[1]!.validation).error).toBeFalsy();
+})
+
+test('triggering schema validation only for one field', async () => {
+	const ctx = createCtx()
+
+	const form = reatomForm({
+		age: 12,
+		email: 'test',
+		items: ['', 'valid']
+	}, {
+		validateOnChange: true,
+		schema: z.object({
+			age: z.number().min(18, 'must be minimum 18'),
+			email: z.string().email(),
+			items: z.array(z.string().min(1))
+		})
+	});
+
+	expect(ctx.get(form.validation).error).toBeFalsy();
+
+	form.fields.age.change(ctx, 17);
+	expect(ctx.get(form.validation).error).toBe('must be minimum 18');
+	expect(ctx.get(form.fields.age.validation).error).toBe('must be minimum 18');
+})
+
+test('concurrent field validation with schema', async () => {
+	const ctx = createCtx()
+
+	const form = reatomForm({
+		age: { 
+			initState: 12, 
+			validate: async () => { 
+				await sleep();
+				throw new Error('validation error')
+			},
+		}
+	}, {
+		validateOnChange: true,
+		schema: z.object({
+			age: z.number().min(18, 'must be minimum 18'),
+		})
+	});
+
+	form.fields.age.change(ctx, 10);
+	expect(ctx.get(form.fields.age.validation).error).toBe('must be minimum 18');
+	await sleep();
+
+	expect(ctx.get(form.fields.age.validation).error).toBe('must be minimum 18');
 })

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { reatomField, reatomForm, withField } from '.'
 import { reatomBoolean } from '@reatom/primitives';
+import { z } from 'zod';
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
@@ -361,4 +362,27 @@ describe('init array with reset', () => {
 		expect(ctx.get(secondNestedItem.number)).toEqual('456')
 		expect(ctx.get(secondNestedItem.priority)).toEqual(true)
 	})
+})
+	
+test('validating through form schema and placing errors to corresponding fields', async () => {
+	const ctx = createCtx()
+
+	const form = reatomForm({
+		age: 12,
+		email: 'test',
+		items: ['', 'valid']
+	}, {
+		schema: z.object({
+			age: z.number().min(18),
+			email: z.string().email(),
+			items: z.array(z.string().min(1))
+		})
+	});
+	
+	form.submit(ctx);
+
+	expect(ctx.get(form.fields.age.validation).error).toBeTruthy();
+	expect(ctx.get(form.fields.email.validation).error).toBeTruthy();
+	expect(ctx.get(ctx.get(form.fields.items.array)[0]!.validation).error).toBeTruthy();
+	expect(ctx.get(ctx.get(form.fields.items.array)[1]!.validation).error).toBeFalsy();
 })

--- a/packages/form/src/reatomForm.test.ts
+++ b/packages/form/src/reatomForm.test.ts
@@ -1,18 +1,18 @@
 import { test, expect, describe } from 'vitest'
 import { createCtx } from '@reatom/core'
-import { reatomField, reatomForm, withField } from '.'
+import { fieldArray, reatomField, reatomForm, withField } from '.'
 import { reatomBoolean } from '@reatom/primitives';
 import { z } from 'zod';
 
 test(`adding and removing fields`, async () => {
 	const ctx = createCtx();
-	const form = reatomForm(fieldArray => ({
+	const form = reatomForm({
 		field: reatomField('initial', 'fieldAtom'),
 		list: fieldArray({
 			initState: ['initial'],
 			create: (ctx, param) => reatomField(param, 'fieldAtom')
 		}),
-	}));
+	});
 
 	expect(ctx.get(form.fields.field)).toBe('initial');
 	expect(ctx.get(form.fields.list).size).toBe(1);
@@ -26,14 +26,14 @@ test(`adding and removing fields`, async () => {
 
 test('focus states', () => {
 	const ctx = createCtx()
-	const form = reatomForm(fieldArray => ({
+	const form = reatomForm({
 		field1: { initState: '', validate: () => { } },
 		field2: { initState: '', validate: () => { } },
 		list: fieldArray({
 			initState: ['initial'],
 			create: (ctx, param) => reatomField(param, 'fieldAtom')
 		}),
-	}));
+	});
 
 	form.fields.field1.change(ctx, 'value')
 	form.fields.field2.change(ctx, 'value')
@@ -79,11 +79,11 @@ test('validation states', async () => {
 			throw new Error('Contract error')
 	}
 
-	const form = reatomForm(fieldArray => ({
+	const form = reatomForm({
 		field1: { initState: '', contract, validateOnChange: true },
 		field2: { initState: '', contract, validateOnChange: true },
 		rest: fieldArray<string>([])
-	}), {
+	}, {
 		name: 'testForm',
 		onSubmit: () => { },
 		validate: () => {
@@ -140,10 +140,10 @@ test('validation states', async () => {
 
 test('default options for fields', async () => {
 	const ctx = createCtx()
-	const form = reatomForm(fieldArray => ({
+	const form = reatomForm({
 		field: { initState: 'initial', validate: () => { } },
 		array: fieldArray(['one', 'two', 'free']),
-	}), {
+	}, {
 		validateOnChange: true
 	});
 
@@ -192,7 +192,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 
 	test('nested array literals and using fieldArray deep inside', () => {
 		const ctx = createCtx()
-		const form = reatomForm(fieldArray => ({
+		const form = reatomForm({
 			nestedArray: [
 				{
 					array: ['hey'],
@@ -200,7 +200,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 					emptyArrayExplicit: fieldArray<string>([])
 				}
 			]
-		}))
+		})
 
 		const nestedArray = ctx.get(form.fields.nestedArray.array);
 		expect(nestedArray.length).toBe(1);
@@ -228,7 +228,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 	test('nested array literals and fieldArray in initState', () => {
 		const ctx = createCtx()
 
-		const form = reatomForm(fieldArray => ({		
+		const form = reatomForm({		
 			addresses: [
 				{
 					country: '',
@@ -244,7 +244,7 @@ describe('fieldArray and array literals as a fieldArray', () => {
 					}),
 				}
 			]
-		}));
+		});
 
 		const addresses = ctx.get(form.fields.addresses.array);
 		const phoneNumbers = addresses[0]!.phoneNumbers;

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -10,7 +10,6 @@ import {
   __count,
   action,
   atom,
-  createCtx,
   isAtom,
 } from '@reatom/core';
 
@@ -475,12 +474,17 @@ const resolveFieldByPath = <T extends FormInitState>(
 
 export function reatomForm<T extends FormInitState, SchemaState>(
 	initState: T | ((name: string) => T),
-	options: FormOptionsWithSchema<SchemaState>
+	optionsWithSchema: FormOptionsWithSchema<SchemaState>
 ): Form<T>
 
 export function reatomForm<T extends FormInitState>(
 	initState: T | ((name: string) => T),
-	options?: string | FormOptionsWithoutSchema<T>
+	options?: FormOptionsWithoutSchema<T>
+): Form<T>
+
+export function reatomForm<T extends FormInitState>(
+	initState: T | ((name: string) => T),
+	name?: string
 ): Form<T>
 
 export function reatomForm<T extends FormInitState, SchemaState>(

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -5,7 +5,6 @@ import {
   AtomMut,
   AtomState,
   type Ctx,
-  CtxSpy,
   type Rec,
   __count,
   action,
@@ -27,8 +26,6 @@ import {
 
 import {
   LLNode,
-  LL_NEXT,
-  LL_PREV,
   LinkedList,
   LinkedListAtom,
   LinkedListLikeAtom,
@@ -37,21 +34,19 @@ import {
   withComputed,
 } from '@reatom/primitives';
 
-import { parseAtoms, withReset, type ParseAtoms } from '@reatom/lens';
-import { entries, isObject, isShallowEqual } from '@reatom/utils';
+import { type ParseAtoms } from '@reatom/lens';
+import { isObject } from '@reatom/utils';
 
 import {
   type FieldAtom,
-  type FieldFocus,
-  type FieldValidation,
-  fieldInitFocus,
-  fieldInitValidation,
   reatomField,
   type FieldOptions,
   FieldLikeAtom,
 } from './reatomField';
 
 import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { withInit } from '@reatom/hooks';
+import { FieldSet, reatomFieldsSet } from './reatomFieldSet';
 
 export interface FormFieldOptions<State = any, Value = State>
   extends FieldOptions<State, Value> {
@@ -82,13 +77,13 @@ type ExtractFieldArray<T> = {
   [K in keyof T]: T[K] extends FormFieldArray<infer Param, infer Node> ? Param[] : ExtractFieldArray<T[K]>
 }
 
-export type FormFieldArrayAtom<Param, Node extends FormInitStateElement = FormInitStateElement>
+export type FormFieldArrayAtom<Param = any, Node extends FormInitStateElement = FormInitStateElement>
   = LinkedListAtom<[ExtractFieldArray<Param>], FormFieldElement<Node>> & {
     reset: Action<[], AtomState<FormFieldArrayAtom<Param, Node>>>
     initState: AtomMut<LinkedList<LLNode<FormFieldElement<Node>>>>
   }
 
-type FormFieldElement<T extends FormInitStateElement = FormInitStateElement> =
+export type FormFieldElement<T extends FormInitStateElement = FormInitStateElement> =
   T extends FieldLikeAtom
   ? T
   : T extends Date
@@ -121,42 +116,20 @@ export type DeepPartial<T, Skip = never> = {
   [K in keyof T]?: T[K] extends Skip ? T[K] : T[K] extends Rec ? DeepPartial<T[K], Skip> : T[K];
 };
 
-type DeepExtractLLNode<T> = {
-  [K in keyof T]: T[K] extends Array<infer LLNode>
-  ? Array<DeepExtractLLNode<Omit<LLNode, typeof LL_NEXT | typeof LL_PREV>>>
-  : T[K]
-}
-
 export type FormPartialState<T extends FormInitState = FormInitState> =
-  DeepPartial<DeepExtractLLNode<FormState<T>>, Array<unknown>>;
+  DeepPartial<FormState<T>, Array<unknown>>;
 
 export interface SubmitAction extends AsyncAction<[], void> {
   error: Atom<Error | undefined>;
   statusesAtom: AsyncStatusesAtom;
 }
 
-export interface Form<T extends FormInitState> {
-  /** Fields from the init state */
-  fields: FormFields<T>;
-
-  /** Atom with the state of the form, computed from all the fields in `fieldsList` */
-  fieldsState: Atom<FormState<T>>;
-
-  /** Atom with focus state of the form, computed from all the fields in `fieldsList` */
-  focus: Atom<FieldFocus>;
-
-  init: Action<[initState: FormPartialState<T>], void>;
-
-  /** Action to reset the state, the value, the validation, and the focus states. */
-  reset: Action<[initState?: FormPartialState<T>], void>;
-
+export interface Form<T extends FormInitState> extends FieldSet<T> {
   /** Submit async handler. It checks the validation of all the fields in `fieldsList`, calls the form's `validate` options handler, and then the `onSubmit` options handler. Check the additional options properties of async action: https://www.reatom.dev/package/async/. */
   submit: SubmitAction;
 
+  /** Atom with submitted state of the form */
   submitted: Atom<boolean>;
-
-  /** Atom with validation state of the form, computed from all the fields in `fieldsList` */
-  validation: Atom<FieldValidation>;
 }
 
 export interface BaseFormOptions {
@@ -290,101 +263,6 @@ const reatomFormFields = <T extends FormInitState>(
   return fields;
 };
 
-const computeFieldsList = <T extends FormInitState>(
-  ctx: CtxSpy,
-  fields: FormFields<T>,
-  acc: Array<FieldAtom> = []
-): Array<FieldAtom> => {
-  const computeElement = (
-    element: FormFieldElement,
-    acc: Array<FieldAtom> = [],
-  ) => {
-    if (isLinkedListAtom(element)) {
-      const elements = ctx.spy(element.array);
-      elements.forEach(e => computeElement(e, acc))
-    }
-    else if (isAtom(element)) acc.push(element);
-    else computeFieldsList(ctx, element, acc);
-
-    return acc;
-  }
-
-  for (const [_, field] of entries(fields))
-    acc.push(...computeElement(field));
-
-  return acc;
-};
-
-const computeFieldArraysList = <T extends FormInitState>(
-  ctx: CtxSpy,
-  fields: FormFields<T>,
-  acc: Array<FormFieldArrayAtom<unknown>> = []
-) => {
-  const computeElement = (
-    element: FormFieldElement,
-    acc: Array<FormFieldArrayAtom<unknown>> = [],
-  ) => {
-    if (isLinkedListAtom(element)) {
-      acc.push(element as FormFieldArrayAtom<unknown>);
-      ctx.spy(element.array).forEach(e => computeElement(e, acc));
-    }
-    else if (!isAtom(element))
-      computeFieldArraysList(ctx, element, acc)
-
-    return acc;
-  }
-
-  for (const [_, field] of entries(fields)) {
-    acc.push(...computeElement(field));
-  }
-
-  return acc;
-};
-
-export const reatomFieldsSet = <T extends FormInitState>(
-	fields: FormFields<T>,
-	name = __count('fieldsSet'),
-) => {
-	const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
-
-	const focus = atom((ctx, state = fieldInitFocus) => {
-		const formFocus = { ...fieldInitFocus };
-
-		for (const field of ctx.spy(fieldsList)) {
-			const { active, dirty, touched } = ctx.spy(field.focus);
-			formFocus.active ||= active;
-			formFocus.dirty ||= dirty;
-			formFocus.touched ||= touched;
-		}
-
-		return isShallowEqual(formFocus, state) ? state : formFocus;
-	}, `${name}.focus`);
-
-	const validation = atom((ctx, state = fieldInitValidation) => {
-		const formValid = { ...fieldInitValidation };
-		formValid.triggered = true;
-
-		for (const field of ctx.spy(fieldsList)) {
-			const { triggered, validating, error } = ctx.spy(field.validation);
-
-			formValid.triggered &&= triggered;
-			formValid.validating ||= validating;
-			formValid.error ||= error;
-		}
-
-		return isShallowEqual(formValid, state) ? state : formValid;
-	}, `${name}.validation`);
-
-	const fieldsState = atom(ctx => parseAtoms(ctx, fields), `${name}.fieldsState`);
-
-	return {
-		fields,
-		fieldsState,
-		focus,
-		validation,
-	};
-};
-
 interface FormFieldArray<Param, Node extends FormInitStateElement = FormInitStateElement> {
   create: (ctx: Ctx, param: Param, name: string) => Node,
   initState: Array<Param>;
@@ -436,7 +314,7 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 
 const isFieldArray = (value: any): value is FormFieldArray<any> => value?.__fieldArray;
 
-export { createFieldArray as fieldArray };
+export { createFieldArray as experimental_fieldArray };
 export type ArrayFieldItem<T> = T extends LinkedListLikeAtom ? AtomState<T['array']>[number] : never;
 
 const resolveFieldByPath = <T extends FormInitState>(
@@ -505,24 +383,24 @@ export function reatomForm<T extends FormInitState, SchemaState>(
       ? ({ name: options })
       : options;
 
-  const defaultFieldOptions = {
-    validateOnBlur,
-    validateOnChange,
-    keepErrorDuringValidating,
-    keepErrorOnChange
-  };
-
   const fields = reatomFormFields(initState instanceof Function ? initState(name) : initState, {
     name: `${name}.fields`,
     onFieldResolved: (field) => {
-			field.__defaults.validateOnChange ??= defaultFieldOptions.validateOnChange;
-			field.__defaults.validateOnBlur ??= defaultFieldOptions.validateOnBlur;
-			field.__defaults.keepErrorDuringValidating ??= defaultFieldOptions.keepErrorDuringValidating;
-			field.__defaults.keepErrorOnChange ??= defaultFieldOptions.keepErrorOnChange;
+      field.options.pipe(
+        withInit((ctx, init) => {
+          const options = init(ctx);
+
+          return {
+            validateOnChange: options.validateOnChange ?? validateOnChange,
+            validateOnBlur: options.validateOnBlur ?? validateOnBlur,
+            keepErrorDuringValidating: options.keepErrorDuringValidating ?? keepErrorDuringValidating,
+            keepErrorOnChange: options.keepErrorOnChange ?? keepErrorOnChange,
+            shouldValidate: !!schema || options.shouldValidate
+          }
+        })
+      )
 
 			if (schema) {
-				field.__defaults.shouldValidate = true;
-
 				field.validation.trigger.onCall((ctx) => {
 					if (!ctx.get(field.validation).error && !isCausedBy(ctx, submit))
 						checkSchemaValidation(ctx, field);
@@ -532,51 +410,22 @@ export function reatomForm<T extends FormInitState, SchemaState>(
   });
   
   const {
+    fieldsList,
+    fieldArraysList,
     fieldsState,
     focus,
-    validation
+    validation,
+    reset,
+    init
   } = reatomFieldsSet(fields, name);
 
-  const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
-  const fieldArraysList = atom(ctx => computeFieldArraysList(ctx, fields), `${name}.fieldArraysList`);
-
-  const submitted = atom(false, `${name}.submitted`);
-
-  const reset = action((ctx, initState?: FormPartialState<T>) => {
-    if (initState)
-      reinitState(ctx, initState, fields);
-
-    ctx.get(fieldArraysList).forEach((fieldArray) => fieldArray.reset(ctx));
-    ctx.get(fieldsList).forEach((fieldAtom) => fieldAtom.reset(ctx));
-
+  reset.onCall((ctx) => {
     submitted(ctx, false);
     submit.errorAtom.reset(ctx);
     submit.abort(ctx, `${name}.reset`);
-  }, `${name}.reset`);
+  })
 
-  const reinitState = (ctx: Ctx, initState: FormPartialState<T>, fields: FormFields) => {
-    for (const [key, value] of Object.entries(initState as Rec)) {
-      if (isLinkedListAtom(fields[key])) {
-        // @ts-expect-error bad type for initiate
-        fields[key].initState(ctx, fields[key].initiate(ctx, value.map(v => [v])));
-      }
-      else if (
-        isObject(value) &&
-        !(value instanceof Date) &&
-        key in fields &&
-        !isAtom(fields[key])
-      ) {
-        reinitState(ctx, value, fields[key] as unknown as FormFields);
-      }
-      else if (isAtom(fields[key])) {
-        fields[key].initState(ctx, value);
-      }
-    }
-  };
-
-  const init = action((ctx, initState: FormPartialState<T>) => {
-    reinitState(ctx, initState, fields);
-  }, `${name}.init`);
+  const submitted = atom(false, `${name}.submitted`);
 
 	const checkSchemaValidation = action(async (ctx: Ctx, triggerOnlyFor?: Atom) => {
 		const state = ctx.get(fieldsState);
@@ -592,12 +441,10 @@ export function reatomForm<T extends FormInitState, SchemaState>(
 				if (!field || (triggerOnlyFor && triggerOnlyFor !== field))
 					continue;
 
-				field.validation.merge(ctx, {
-					error: issue.message,
-					meta: undefined,
-					triggered: true,
-					validating: false,
-				});
+        if (ctx.get(field.disabled))
+          continue;
+
+        field.validation.setError(ctx, issue.message)
 
 				if (triggerOnlyFor)
 					break;
@@ -666,12 +513,14 @@ export function reatomForm<T extends FormInitState, SchemaState>(
 
   return {
     fields,
+    fieldsList,
+    fieldArraysList,
     fieldsState,
     focus,
     init,
     reset,
     submit,
     submitted,
-    validation,
+    validation
   };
 };

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -81,11 +81,11 @@ type ExtractFieldArray<T> = {
   [K in keyof T]: T[K] extends FormFieldArray<infer Param, infer Node> ? Param[] : ExtractFieldArray<T[K]>
 }
 
-export type FormFieldArrayAtom<Param, Node extends FormInitStateElement = FormInitStateElement> 
+export type FormFieldArrayAtom<Param, Node extends FormInitStateElement = FormInitStateElement>
   = LinkedListAtom<[ExtractFieldArray<Param>], FormFieldElement<Node>> & {
-  reset: Action<[], AtomState<FormFieldArrayAtom<Param, Node>>>
-  initState: AtomMut<LinkedList<LLNode<FormFieldElement<Node>>>>
-}
+    reset: Action<[], AtomState<FormFieldArrayAtom<Param, Node>>>
+    initState: AtomMut<LinkedList<LLNode<FormFieldElement<Node>>>>
+  }
 
 type FormFieldElement<T extends FormInitStateElement = FormInitStateElement> =
   T extends FieldLikeAtom
@@ -94,7 +94,7 @@ type FormFieldElement<T extends FormInitStateElement = FormInitStateElement> =
   ? FieldAtom<T>
   : T extends Array<infer Item>
   ? Item extends FormInitStateElement
-  ? FormFieldElement<FormFieldArray<Item, Item>>
+  ? FormFieldArrayAtom<Item, Item>
   : never
   : T extends FormFieldArray<infer Param, infer Node>
   ? FormFieldArrayAtom<Param, Node>
@@ -121,9 +121,9 @@ export type DeepPartial<T, Skip = never> = {
 };
 
 type DeepExtractLLNode<T> = {
-  [K in keyof T]: T[K] extends Array<infer LLNode> 
-    ? Array<DeepExtractLLNode<Omit<LLNode, typeof LL_NEXT | typeof LL_PREV>>> 
-    : T[K]
+  [K in keyof T]: T[K] extends Array<infer LLNode>
+  ? Array<DeepExtractLLNode<Omit<LLNode, typeof LL_NEXT | typeof LL_PREV>>>
+  : T[K]
 }
 
 export type FormPartialState<T extends FormInitState = FormInitState> =
@@ -134,7 +134,7 @@ export interface SubmitAction extends AsyncAction<[], void> {
   statusesAtom: AsyncStatusesAtom;
 }
 
-export interface Form<T extends FormInitState = any> {
+export interface Form<T extends FormInitState> {
   /** Fields from the init state */
   fields: FormFields<T>;
 
@@ -158,7 +158,7 @@ export interface Form<T extends FormInitState = any> {
   validation: Atom<FieldValidation>;
 }
 
-export interface FormOptions<T extends FormInitState = any> {
+export interface FormOptions<T extends FormInitState, State> {
   name?: string;
 
   /** The callback to process valid form data */
@@ -168,7 +168,7 @@ export interface FormOptions<T extends FormInitState = any> {
   validate?: (ctx: Ctx, state: FormState<T>) => any;
 
   /** The schema which supports StandardSchemaV1 specification to validate form fields. */
-  schema?: StandardSchemaV1<FormState<T>>;
+  schema?: StandardSchemaV1<State>;
 
   /** Should reset the state after success submit? @default true */
   resetOnSubmit?: boolean;
@@ -274,12 +274,12 @@ const computeFieldsList = <T extends FormInitState>(
   acc: Array<FieldAtom> = []
 ): Array<FieldAtom> => {
   const computeElement = (
-    element: FormFieldElement, 
+    element: FormFieldElement,
     acc: Array<FieldAtom> = [],
   ) => {
     if (isLinkedListAtom(element)) {
       const elements = ctx.spy(element.array);
-      acc.push(...elements.flatMap(e => computeElement(e, acc)));
+      elements.forEach(e => computeElement(e, acc))
     }
     else if (isAtom(element)) acc.push(element);
     else computeFieldsList(ctx, element, acc);
@@ -293,27 +293,28 @@ const computeFieldsList = <T extends FormInitState>(
   return acc;
 };
 
-const getFieldArraysList = <T extends FormInitState>(
-  ctx: Ctx,
+const computeFieldArraysList = <T extends FormInitState>(
+  ctx: CtxSpy,
   fields: FormFields<T>,
   acc: Array<FormFieldArrayAtom<unknown>> = []
 ) => {
   const computeElement = (
-    element: FormFieldElement, 
+    element: FormFieldElement,
     acc: Array<FormFieldArrayAtom<unknown>> = [],
   ) => {
     if (isLinkedListAtom(element)) {
       acc.push(element as FormFieldArrayAtom<unknown>);
-      acc.push(...ctx.get(element.array).flatMap(e => computeElement(e, acc)));
+      ctx.spy(element.array).forEach(e => computeElement(e, acc));
     }
     else if (!isAtom(element))
-      getFieldArraysList(ctx, element)
+      computeFieldArraysList(ctx, element, acc)
 
     return acc;
   }
 
-  for (const [_, field] of entries(fields))
+  for (const [_, field] of entries(fields)) {
     acc.push(...computeElement(field));
+  }
 
   return acc;
 };
@@ -354,7 +355,7 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
   } = typeof options === 'function'
       ? { create: options }
       : Array.isArray(options)
-        ? { 
+        ? {
           create: (ctx: Ctx, param: Param) => param as unknown as Node,
           initState: options
         }
@@ -370,8 +371,8 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 const isFieldArray = (value: any): value is FormFieldArray<any> => value?.__fieldArray;
 
 const resolveFieldByPath = <T extends FormInitState>(
-  ctx: Ctx, 
-  path: StandardSchemaV1.Issue['path'], 
+  ctx: Ctx,
+  path: StandardSchemaV1.Issue['path'],
   acc: FormFields<T>
 ): FieldAtom | null => {
   if (!path?.length)
@@ -398,14 +399,16 @@ const resolveFieldByPath = <T extends FormInitState>(
     return field
   }
   else {
-    // @ts-expect-error will be Rec in this case
-    return resolveFieldByPath(shiftedPath, field)
+    return resolveFieldByPath(ctx, shiftedPath, field)
   }
 }
 
-export const reatomForm = <T extends FormInitState>(
+export const reatomForm = <
+  T extends FormInitState,
+  SchemaState extends DeepExtractLLNode<FormState<T>>
+>(
   initState: T | ((fieldArray: typeof createFieldArray) => T),
-  options: string | FormOptions<T> = {},
+  options: string | FormOptions<T, SchemaState> = {},
 ): Form<T> => {
   const {
     name = __count('form'),
@@ -418,7 +421,7 @@ export const reatomForm = <T extends FormInitState>(
     keepErrorOnChange = !validateOnChange,
     schema,
   } = typeof options === 'string'
-      ? ({ name: options } as FormOptions<T>)
+      ? ({ name: options } as FormOptions<T, SchemaState>)
       : options;
 
   const fields = reatomFormFields(initState instanceof Function ? initState(createFieldArray) : initState, {
@@ -437,7 +440,7 @@ export const reatomForm = <T extends FormInitState>(
   );
 
   const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
-  const fieldArraysList = atom(ctx => getFieldArraysList(ctx, fields), `${name}.fieldArraysList`);
+  const fieldArraysList = atom(ctx => computeFieldArraysList(ctx, fields), `${name}.fieldArraysList`);
 
   const focus = atom((ctx, state = fieldInitFocus) => {
     const formFocus = { ...fieldInitFocus };
@@ -470,7 +473,7 @@ export const reatomForm = <T extends FormInitState>(
   const submitted = atom(false, `${name}.submitted`);
 
   const reset = action((ctx, initState?: FormPartialState<T>) => {
-    if(initState)
+    if (initState)
       reinitState(ctx, initState, fields);
 
     ctx.get(fieldArraysList).forEach((fieldArray) => fieldArray.reset(ctx));
@@ -505,6 +508,31 @@ export const reatomForm = <T extends FormInitState>(
     reinitState(ctx, initState, fields);
   }, `${name}.init`);
 
+  const checkSchemaValidation = async (ctx: Ctx, state: FormState<T>) => {
+    if (!schema)
+      return null;
+
+    const validation = schema['~standard'].validate(state);
+    const result = validation instanceof Promise ? await ctx.schedule(() => validation) : validation;
+
+    if (result.issues?.length) {
+      for (const issue of result.issues) {
+        const field = resolveFieldByPath(ctx, issue.path, fields);
+        if (!field)
+          continue;
+
+        field.validation.merge(ctx, {
+          error: issue.message,
+          meta: undefined,
+          triggered: true,
+          validating: false,
+        })
+      }
+    }
+
+    return result;
+  }
+
   const submit = reatomAsync(async (ctx) => {
     ctx.get(() => {
       for (const field of ctx.get(fieldsList)) {
@@ -533,27 +561,9 @@ export const reatomForm = <T extends FormInitState>(
       }
     }
 
-    if (schema) {
-      const validation = schema['~standard'].validate(state);
-      const result = validation instanceof Promise ? await ctx.schedule(() => validation) : validation;
-
-      if (result.issues?.length) {
-        for (const issue of result.issues) {
-          const field = resolveFieldByPath(ctx, issue.path, fields);
-          if (!field)
-            continue;
-
-          field.validation.merge(ctx, {
-            error: issue.message,
-            meta: undefined,
-            triggered: true,
-            validating: false,
-          })
-        }
-
-        throw new Error(result.issues[0]!.message);
-      }
-    }
+    const schemaValidationResult = await checkSchemaValidation(ctx, state);
+    if (schemaValidationResult && schemaValidationResult.issues?.length)
+      throw new Error(schemaValidationResult.issues[0]!.message);
 
     if (onSubmit) await ctx.schedule(() => onSubmit(ctx, state));
 
@@ -572,6 +582,16 @@ export const reatomForm = <T extends FormInitState>(
     withErrorAtom(undefined, { resetTrigger: 'onFulfill' }),
     (submit) => Object.assign(submit, { error: submit.errorAtom }),
   );
+
+  if(validateOnChange) {
+    fieldsState.onChange((ctx, state) => {
+      const changeCause = ctx.cause?.cause;
+      const fieldArrayProtos = new Set(ctx.get(fieldArraysList).map(fieldArray => fieldArray.array.__reatom));
+
+      if(changeCause && !fieldArrayProtos.has(changeCause.proto))
+        checkSchemaValidation(ctx, state);
+    })
+  }
 
   return {
     fields,

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -50,6 +50,8 @@ import {
   FieldLikeAtom,
 } from './reatomField';
 
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
 export interface FormFieldOptions<State = any, Value = State>
   extends FieldOptions<State, Value> {
   initState: State;
@@ -164,6 +166,9 @@ export interface FormOptions<T extends FormInitState = any> {
 
   /** The callback to validate form fields. */
   validate?: (ctx: Ctx, state: FormState<T>) => any;
+
+  /** The schema which supports StandardSchemaV1 specification to validate form fields. */
+  schema?: StandardSchemaV1<FormState<T>>;
 
   /** Should reset the state after success submit? @default true */
   resetOnSubmit?: boolean;
@@ -364,6 +369,40 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 
 const isFieldArray = (value: any): value is FormFieldArray<any> => value?.__fieldArray;
 
+const resolveFieldByPath = <T extends FormInitState>(
+  ctx: Ctx, 
+  path: StandardSchemaV1.Issue['path'], 
+  acc: FormFields<T>
+): FieldAtom | null => {
+  if (!path?.length)
+    return null;
+
+  const shiftedPath = [...path];
+  const pathSegment = shiftedPath.shift()!;
+  if (typeof pathSegment === 'symbol')
+    return null;
+
+  const key = typeof pathSegment === 'object' && 'key' in pathSegment
+    ? pathSegment.key.toString()
+    : pathSegment.toString();
+
+  const field = acc[key];
+  if (!field)
+    return null;
+
+  if (isLinkedListAtom(field)) {
+    // @ts-expect-error bad key inference
+    return resolveFieldByPath(ctx, shiftedPath, ctx.get(field.array))
+  }
+  else if (isAtom(field)) {
+    return field
+  }
+  else {
+    // @ts-expect-error will be Rec in this case
+    return resolveFieldByPath(shiftedPath, field)
+  }
+}
+
 export const reatomForm = <T extends FormInitState>(
   initState: T | ((fieldArray: typeof createFieldArray) => T),
   options: string | FormOptions<T> = {},
@@ -377,6 +416,7 @@ export const reatomForm = <T extends FormInitState>(
     validateOnChange = false,
     keepErrorDuringValidating = false,
     keepErrorOnChange = !validateOnChange,
+    schema,
   } = typeof options === 'string'
       ? ({ name: options } as FormOptions<T>)
       : options;
@@ -488,8 +528,30 @@ export const reatomForm = <T extends FormInitState>(
 
     if (validate) {
       const promise = validate(ctx, state);
-      if (promise instanceof promise) {
+      if (promise instanceof Promise) {
         await ctx.schedule(() => promise);
+      }
+    }
+
+    if (schema) {
+      const validation = schema['~standard'].validate(state);
+      const result = validation instanceof Promise ? await ctx.schedule(() => validation) : validation;
+
+      if (result.issues?.length) {
+        for (const issue of result.issues) {
+          const field = resolveFieldByPath(ctx, issue.path, fields);
+          if (!field)
+            continue;
+
+          field.validation.merge(ctx, {
+            error: issue.message,
+            meta: undefined,
+            triggered: true,
+            validating: false,
+          })
+        }
+
+        throw new Error(result.issues[0]!.message);
       }
     }
 

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -14,7 +14,7 @@ import {
   isAtom,
 } from '@reatom/core';
 
-import { take } from '@reatom/effects';
+import { isCausedBy, take } from '@reatom/effects';
 
 import {
   type AsyncAction,
@@ -23,6 +23,7 @@ import {
   type AsyncStatusesAtom,
   reatomAsync,
   withAbort,
+  AsyncCtx,
 } from '@reatom/async';
 
 import {
@@ -31,6 +32,7 @@ import {
   LL_PREV,
   LinkedList,
   LinkedListAtom,
+  LinkedListLikeAtom,
   isLinkedListAtom,
   reatomLinkedList,
   withComputed,
@@ -158,17 +160,8 @@ export interface Form<T extends FormInitState> {
   validation: Atom<FieldValidation>;
 }
 
-export interface FormOptions<T extends FormInitState, State> {
+export interface BaseFormOptions {
   name?: string;
-
-  /** The callback to process valid form data */
-  onSubmit?: (ctx: Ctx, state: FormState<T>) => void | Promise<void>;
-
-  /** The callback to validate form fields. */
-  validate?: (ctx: Ctx, state: FormState<T>) => any;
-
-  /** The schema which supports StandardSchemaV1 specification to validate form fields. */
-  schema?: StandardSchemaV1<State>;
 
   /** Should reset the state after success submit? @default true */
   resetOnSubmit?: boolean;
@@ -199,20 +192,43 @@ export interface FormOptions<T extends FormInitState, State> {
   validateOnBlur?: boolean
 }
 
+export interface FormOptionsWithSchema<State> extends BaseFormOptions {
+	/** The callback to process valid form data, typed according to the schema */
+	onSubmit?: (ctx: AsyncCtx, state: State) => void | Promise<void>
+
+	/** The callback to validate form fields, typed according to the schema */
+	validate?: (ctx: Ctx, state: State) => any
+
+	/** The schema which supports StandardSchemaV1 specification to validate form fields. */
+	schema: StandardSchemaV1<State>
+}
+
+export interface FormOptionsWithoutSchema<T extends FormInitState> extends BaseFormOptions {
+	/** The callback to process valid form data, typed according to the raw form state */
+	onSubmit?: (ctx: AsyncCtx, state: FormState<T>) => void | Promise<void>
+
+	/** The callback to validate form fields, typed according to the raw form state */
+	validate?: (ctx: Ctx, state: FormState<T>) => any
+
+	/** Schema is explicitly disallowed or undefined in this variant */
+	schema?: undefined
+}
+
 const reatomFormFields = <T extends FormInitState>(
   initState: T,
   options: {
     name: string,
-    defaultFieldOptions?: FieldOptions
+    onFieldResolved?: (field: FieldAtom) => void
   }
 ): FormFields<T> => {
-  const { name, defaultFieldOptions } = options;
+  const { name, onFieldResolved } = options;
   const fields = Array.isArray(initState)
     ? ([] as FormFields<T>)
     : ({} as FormFields<T>);
 
   const createFieldElement = (element: FormInitStateElement, name: string): FormFieldElement => {
     if (isAtom(element)) {
+      onFieldResolved?.(element)
       return element
     }
     else if (isObject(element) && !(element instanceof Date)) {
@@ -222,7 +238,10 @@ const reatomFormFields = <T extends FormInitState>(
       else if (isFieldArray(element)) {
         let id = 0;
         const linkedListAtom = reatomLinkedList({
-          create: (ctx, param) => createFieldElement(element.create(ctx, param), `${name}.${++id}`),
+          create: (ctx, param) => {
+            const itemName = `${name}.${++id}`;
+            return createFieldElement(element.create(ctx, param, itemName), itemName)
+          },
           initSnapshot: element.initState.map(state => ([state] as const))
         }, name);
 
@@ -245,19 +264,23 @@ const reatomFormFields = <T extends FormInitState>(
         });
       }
       else if ('initState' in element) {
-        return reatomField(element.initState, {
-          name,
-          ...defaultFieldOptions,
-          ...(element as FieldOptions),
-        });
+				const field = reatomField(element.initState, {
+					name,
+					...(element as FieldOptions),
+				})
+
+				onFieldResolved?.(field)
+				return field
       }
       else {
         // @ts-expect-error bad keys type inference
-        return reatomFormFields(element, { name, defaultFieldOptions })
+        return reatomFormFields(element, { name, onFieldResolved })
       }
     }
     else {
-      return reatomField(element, { name, ...defaultFieldOptions })
+      const field = reatomField(element, { name })
+      onFieldResolved?.(field)
+      return field
     }
   }
 
@@ -319,8 +342,52 @@ const computeFieldArraysList = <T extends FormInitState>(
   return acc;
 };
 
+export const reatomFieldsSet = <T extends FormInitState>(
+	fields: FormFields<T>,
+	name = __count('fieldsSet'),
+) => {
+	const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
+
+	const focus = atom((ctx, state = fieldInitFocus) => {
+		const formFocus = { ...fieldInitFocus };
+
+		for (const field of ctx.spy(fieldsList)) {
+			const { active, dirty, touched } = ctx.spy(field.focus);
+			formFocus.active ||= active;
+			formFocus.dirty ||= dirty;
+			formFocus.touched ||= touched;
+		}
+
+		return isShallowEqual(formFocus, state) ? state : formFocus;
+	}, `${name}.focus`);
+
+	const validation = atom((ctx, state = fieldInitValidation) => {
+		const formValid = { ...fieldInitValidation };
+		formValid.triggered = true;
+
+		for (const field of ctx.spy(fieldsList)) {
+			const { triggered, validating, error } = ctx.spy(field.validation);
+
+			formValid.triggered &&= triggered;
+			formValid.validating ||= validating;
+			formValid.error ||= error;
+		}
+
+		return isShallowEqual(formValid, state) ? state : formValid;
+	}, `${name}.validation`);
+
+	const fieldsState = atom(ctx => parseAtoms(ctx, fields), `${name}.fieldsState`);
+
+	return {
+		fields,
+		fieldsState,
+		focus,
+		validation,
+	};
+};
+
 interface FormFieldArray<Param, Node extends FormInitStateElement = FormInitStateElement> {
-  create: (ctx: Ctx, param: Param) => Node,
+  create: (ctx: Ctx, param: Param, name: string) => Node,
   initState: Array<Param>;
   __fieldArray: true;
 }
@@ -330,12 +397,12 @@ function createFieldArray<Param extends FormInitStateElement>(
 ): FormFieldArray<Param, Param>;
 
 function createFieldArray<Param, Node extends FormInitStateElement = FormInitStateElement>(
-  create: ((ctx: Ctx, params: Param) => Node)
+  create: ((ctx: Ctx, params: Param, name: string) => Node)
 ): FormFieldArray<Param, Node>;
 
 function createFieldArray<Param, Node extends FormInitStateElement = FormInitStateElement>(
   options: {
-    create: (ctx: Ctx, param: Param) => Node
+    create: (ctx: Ctx, param: Param, name: string) => Node
     initState?: Array<Param>,
   }
 ): FormFieldArray<Param, Node>;
@@ -343,9 +410,9 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 function createFieldArray<Param, Node extends FormInitStateElement = FormInitStateElement>(
   options:
     | Array<Param>
-    | ((ctx: Ctx, params: Param) => Node)
+    | ((ctx: Ctx, params: Param, name: string) => Node)
     | {
-      create: (ctx: Ctx, param: Param) => Node
+      create: (ctx: Ctx, param: Param, name: string) => Node
       initState?: Array<Param>,
     }
 ): FormFieldArray<Param, Node> {
@@ -371,6 +438,7 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 const isFieldArray = (value: any): value is FormFieldArray<any> => value?.__fieldArray;
 
 export { createFieldArray as fieldArray };
+export type ArrayFieldItem<T> = T extends LinkedListLikeAtom ? AtomState<T['array']>[number] : never;
 
 const resolveFieldByPath = <T extends FormInitState>(
   ctx: Ctx,
@@ -405,13 +473,20 @@ const resolveFieldByPath = <T extends FormInitState>(
   }
 }
 
-export const reatomForm = <
-  T extends FormInitState,
-  SchemaState extends DeepExtractLLNode<FormState<T>>
->(
-  initState: T,
-  options: string | FormOptions<T, SchemaState> = {},
-): Form<T> => {
+export function reatomForm<T extends FormInitState, SchemaState>(
+	initState: T | ((name: string) => T),
+	options: FormOptionsWithSchema<SchemaState>
+): Form<T>
+
+export function reatomForm<T extends FormInitState>(
+	initState: T | ((name: string) => T),
+	options?: string | FormOptionsWithoutSchema<T>
+): Form<T>
+
+export function reatomForm<T extends FormInitState, SchemaState>(
+	initState: T | ((name: string) => T),
+	options: string | FormOptionsWithSchema<SchemaState> | FormOptionsWithoutSchema<T> = {},
+): Form<T> {
   const {
     name = __count('form'),
     onSubmit,
@@ -423,54 +498,43 @@ export const reatomForm = <
     keepErrorOnChange = !validateOnChange,
     schema,
   } = typeof options === 'string'
-      ? ({ name: options } as FormOptions<T, SchemaState>)
+      ? ({ name: options })
       : options;
 
-  const fields = reatomFormFields(initState instanceof Function ? initState(createFieldArray) : initState, {
-    name: `${name}.fields`,
-    defaultFieldOptions: {
-      validateOnBlur,
-      validateOnChange,
-      keepErrorDuringValidating,
-      keepErrorOnChange
-    }
-  });
+  const defaultFieldOptions = {
+    validateOnBlur,
+    validateOnChange,
+    keepErrorDuringValidating,
+    keepErrorOnChange
+  };
 
-  const fieldsState = atom(
-    (ctx) => parseAtoms(ctx, fields),
-    `${name}.fieldsState`,
-  );
+  const fields = reatomFormFields(initState instanceof Function ? initState(name) : initState, {
+    name: `${name}.fields`,
+    onFieldResolved: (field) => {
+			field.__defaults.validateOnChange ??= defaultFieldOptions.validateOnChange;
+			field.__defaults.validateOnBlur ??= defaultFieldOptions.validateOnBlur;
+			field.__defaults.keepErrorDuringValidating ??= defaultFieldOptions.keepErrorDuringValidating;
+			field.__defaults.keepErrorOnChange ??= defaultFieldOptions.keepErrorOnChange;
+
+			if (schema) {
+				field.__defaults.shouldValidate = true;
+
+				field.validation.trigger.onCall((ctx) => {
+					if (!ctx.get(field.validation).error && !isCausedBy(ctx, submit))
+						checkSchemaValidation(ctx, field);
+				});
+			}
+		},
+  });
+  
+  const {
+    fieldsState,
+    focus,
+    validation
+  } = reatomFieldsSet(fields, name);
 
   const fieldsList = atom(ctx => computeFieldsList(ctx, fields), `${name}.fieldsList`);
   const fieldArraysList = atom(ctx => computeFieldArraysList(ctx, fields), `${name}.fieldArraysList`);
-
-  const focus = atom((ctx, state = fieldInitFocus) => {
-    const formFocus = { ...fieldInitFocus };
-
-    for (const field of ctx.spy(fieldsList)) {
-      const { active, dirty, touched } = ctx.spy(field.focus);
-      formFocus.active ||= active;
-      formFocus.dirty ||= dirty;
-      formFocus.touched ||= touched;
-    }
-
-    return isShallowEqual(formFocus, state) ? state : formFocus;
-  }, `${name}.focus`);
-
-  const validation = atom((ctx, state = fieldInitValidation) => {
-    const formValid = { ...fieldInitValidation };
-    formValid.triggered = true;
-
-    for (const field of ctx.spy(fieldsList)) {
-      const { triggered, validating, error } = ctx.spy(field.validation);
-
-      formValid.triggered &&= triggered;
-      formValid.validating ||= validating;
-      formValid.error ||= error;
-    }
-
-    return isShallowEqual(formValid, state) ? state : formValid;
-  }, `${name}.validation`);
 
   const submitted = atom(false, `${name}.submitted`);
 
@@ -510,30 +574,34 @@ export const reatomForm = <
     reinitState(ctx, initState, fields);
   }, `${name}.init`);
 
-  const checkSchemaValidation = async (ctx: Ctx, state: FormState<T>) => {
-    if (!schema)
-      return null;
+	const checkSchemaValidation = action(async (ctx: Ctx, triggerOnlyFor?: Atom) => {
+		const state = ctx.get(fieldsState);
+		if (!schema)
+			throw new Error('Triggering schema validation without schema');
 
-    const validation = schema['~standard'].validate(state);
-    const result = validation instanceof Promise ? await ctx.schedule(() => validation) : validation;
+		const validation = schema['~standard'].validate(state);
+		const result = validation instanceof Promise ? await ctx.schedule(() => validation) : validation;
 
-    if (result.issues?.length) {
-      for (const issue of result.issues) {
-        const field = resolveFieldByPath(ctx, issue.path, fields);
-        if (!field)
-          continue;
+		if (result.issues?.length) {
+			for (const issue of result.issues) {
+				const field = resolveFieldByPath(ctx, issue.path, fields);
+				if (!field || (triggerOnlyFor && triggerOnlyFor !== field))
+					continue;
 
-        field.validation.merge(ctx, {
-          error: issue.message,
-          meta: undefined,
-          triggered: true,
-          validating: false,
-        })
-      }
-    }
+				field.validation.merge(ctx, {
+					error: issue.message,
+					meta: undefined,
+					triggered: true,
+					validating: false,
+				});
 
-    return result;
-  }
+				if (triggerOnlyFor)
+					break;
+			}
+		}
+
+		return result;
+	}, `${name}.checkSchemaValidation`);
 
   const submit = reatomAsync(async (ctx) => {
     ctx.get(() => {
@@ -554,18 +622,25 @@ export const reatomForm = <
 
     if (error) throw new Error(error);
 
-    const state = ctx.get(fieldsState);
+    let state: any
 
+		if (schema) {
+			const schemaValidationResult = await ctx.schedule(() => checkSchemaValidation(ctx));
+			if (!('value' in schemaValidationResult))
+				throw new Error(schemaValidationResult.issues[0]?.message ?? 'Unknown schema error');
+
+			state = schemaValidationResult.value;
+		}
+		else {
+			state = ctx.get(fieldsState);
+		}
+    
     if (validate) {
       const promise = validate(ctx, state);
       if (promise instanceof Promise) {
         await ctx.schedule(() => promise);
       }
     }
-
-    const schemaValidationResult = await checkSchemaValidation(ctx, state);
-    if (schemaValidationResult && schemaValidationResult.issues?.length)
-      throw new Error(schemaValidationResult.issues[0]!.message);
 
     if (onSubmit) await ctx.schedule(() => onSubmit(ctx, state));
 
@@ -584,16 +659,6 @@ export const reatomForm = <
     withErrorAtom(undefined, { resetTrigger: 'onFulfill' }),
     (submit) => Object.assign(submit, { error: submit.errorAtom }),
   );
-
-  if(validateOnChange) {
-    fieldsState.onChange((ctx, state) => {
-      const changeCause = ctx.cause?.cause;
-      const fieldArrayProtos = new Set(ctx.get(fieldArraysList).map(fieldArray => fieldArray.array.__reatom));
-
-      if(changeCause && !fieldArrayProtos.has(changeCause.proto))
-        checkSchemaValidation(ctx, state);
-    })
-  }
 
   return {
     fields,

--- a/packages/form/src/reatomForm.ts
+++ b/packages/form/src/reatomForm.ts
@@ -370,6 +370,8 @@ function createFieldArray<Param, Node extends FormInitStateElement = FormInitSta
 
 const isFieldArray = (value: any): value is FormFieldArray<any> => value?.__fieldArray;
 
+export { createFieldArray as fieldArray };
+
 const resolveFieldByPath = <T extends FormInitState>(
   ctx: Ctx,
   path: StandardSchemaV1.Issue['path'],
@@ -407,7 +409,7 @@ export const reatomForm = <
   T extends FormInitState,
   SchemaState extends DeepExtractLLNode<FormState<T>>
 >(
-  initState: T | ((fieldArray: typeof createFieldArray) => T),
+  initState: T,
   options: string | FormOptions<T, SchemaState> = {},
 ): Form<T> => {
   const {

--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declarationMap": true
+    "declarationMap": true,
+    "jsx": "react-jsx"
   }
 }

--- a/packages/lens/src/parseAtoms.ts
+++ b/packages/lens/src/parseAtoms.ts
@@ -3,6 +3,7 @@ import {
   isLinkedListAtom,
   LinkedList,
   LinkedListLikeAtom,
+  LLNode,
 } from '@reatom/primitives'
 import { isRec } from '@reatom/utils'
 
@@ -12,7 +13,7 @@ type Builtin = Date | RegExp | Function
 export type ParseAtoms<T> = T extends Action
   ? T
   : T extends LinkedListLikeAtom<infer T>
-  ? T extends LinkedList<infer T>
+  ? T extends LinkedList<LLNode<infer T>>
   ? Array<ParseAtoms<T>>
   : never
   : T extends Atom<infer T>

--- a/packages/primitives/src/reatomArray.ts
+++ b/packages/primitives/src/reatomArray.ts
@@ -1,7 +1,11 @@
 import { Action, AtomMut, action, atom } from '@reatom/core'
 import { withAssign } from './withAssign'
 
-export interface ArrayAtom<T> extends AtomMut<Array<T>> {
+export interface ArrayLikeAtom<T = any> extends AtomMut<Array<T>> {
+  __reatomArray: true
+}
+
+export interface ArrayAtom<T> extends ArrayLikeAtom<T> {
   toReversed: Action<[], T[]>
   toSorted: Action<[compareFn?: (a: T, b: T) => number], T[]>
   toSpliced: Action<[start: number, deleteCount: number, ...items: T[]], T[]>
@@ -18,6 +22,8 @@ export const reatomArray = <T>(
 ): ArrayAtom<T> =>
   atom(initState, name).pipe(
     withAssign((target, name) => ({
+      __reatomArray: true as const,
+      
       toReversed: action(
         (ctx) => target(ctx, (prev) => prev.slice().reverse()),
         `${name}.toReversed`,
@@ -76,3 +82,5 @@ export const reatomArray = <T>(
       }, `${name}.unshift`),
     })),
   )
+
+export const isArrayAtom = (thing: any): thing is ArrayLikeAtom => thing?.__reatomArray === true

--- a/packages/primitives/src/reatomSet.ts
+++ b/packages/primitives/src/reatomSet.ts
@@ -1,7 +1,11 @@
 import { Action, action, atom, Atom, AtomMut, Ctx } from '@reatom/core'
 import { withAssign } from './withAssign'
 
-export interface SetAtom<T> extends AtomMut<Set<T>> {
+export interface SetLikeAtom<T = any> extends AtomMut<Set<T>> {
+  __reatomSet: true
+}
+
+export interface SetAtom<T> extends SetLikeAtom<T> {
   add: Action<[el: T], Set<T>>
   delete: Action<[el: T], Set<T>>
   toggle: Action<[el: T], Set<T>>
@@ -42,6 +46,8 @@ export const reatomSet = <T>(
   
   return atom(atomInitState, name).pipe(
     withAssign((target, name) => ({
+      __reatomSet: true as const,
+      
       add: action(
         (ctx, el) =>
           target(ctx, (prev) => (prev.has(el) ? prev : new Set(prev).add(el))),
@@ -110,3 +116,5 @@ export const reatomSet = <T>(
     })),
   )
 }
+
+export const isSetAtom = (thing: any): thing is SetLikeAtom => thing?.__reatomSet === true


### PR DESCRIPTION
* Added `withField` operator which uses an atom as a field
* Added centralized initialization of fields in form
* Added field arrays with nesting support (using `reatomLinkedList` underhood)

```ts
const form = reatomForm(name => ({
  user: {
    name: '', // empty string field
    email: {  // string field by passing field options explicitly
      initState: '',
      contract: (input: string) => invariant(input.includes('@'))
    },
    password: reatomField('', `${name}.user.password`),
  },

  // custom atoms also supported by piping `withField`
  subject: reatomEnum(['general', 'support'], `${name}.subject`).pipe(withField('general')) 

  // fields array with default value
  addresses: [ 
    { country: '', street: '', city: '' }
  ],
}));
```

Example with nested field arrays:
```ts
const form = reatomForm({
  addresses: fieldArray({
    initState: [
      {
        country: '',
        street: '',
        city: '',
        tags: ['defaultTag', 'defaultTag2'],
        phoneNumbers: Array<{ number: string, priority: boolean }>(),
      }
    ],
    create: (ctx, { city, country, street, tags, phoneNumbers }) => ({
      country,
      street,
      city,

      // use fieldArray overload with default factory
      tags,

      // OR define the factory explicitly to take control of the creation behavior
      phoneNumbers: fieldArray({
        initState: phoneNumbers,
        create: (ctx, { number, priority }, name) => ({
          number,
          priority: reatomBoolean(priority, name).pipe(withField(priority))
        })
      }),
    })
  }),
});
```
Here we using `create` factory to define how we want to create the actual field.