### PR TITLE
feat(primitives): constructor as initializer for primitives

### DIFF
--- a/packages/primitives/src/reatomLinkedList.test.ts
+++ b/packages/primitives/src/reatomLinkedList.test.ts
@@ -189,9 +189,9 @@ describe('reatomLinkedList', () => {
   
     const track = ctx.subscribeTrack(atom((ctx) => [...ctx.spy(list.map).keys()]))
   
-    expect(track.lastInput()).toBe(['1', '2'])
+    expect(track.lastInput()).toStrictEqual(['1', '2'])
   
     ctx.get(list.map).get('1')?.id(ctx, '0')
-    expect(track.lastInput()).toBe(['0', '2'])
+    expect(track.lastInput()).toStrictEqual(['0', '2'])
   })
 })

--- a/packages/primitives/src/reatomLinkedList.test.ts
+++ b/packages/primitives/src/reatomLinkedList.test.ts
@@ -1,4 +1,4 @@
-import { action, atom } from '@reatom/core'
+import { action, atom, isAtom } from '@reatom/core'
 import { createTestCtx } from '@reatom/testing'
 import { describe, test, expect } from 'vitest'
 import { LL_NEXT, LL_PREV, reatomLinkedList } from './reatomLinkedList'
@@ -167,5 +167,31 @@ describe('reatomLinkedList', () => {
 
     ctx.get(list.map).get('1')?.id(ctx, '0')
     expect(track.lastInput()).toEqual(['0', '2'])
+  })
+
+  test('should accept array as initState', () => {
+    const ctx = createTestCtx()
+    const list = reatomLinkedList([atom(1), atom(2)]);
+  
+    expect(ctx.get(list.array).every(isAtom)).toBeTruthy();
+  
+    list.create(ctx, atom(3));
+    expect(ctx.get(list.array).every(isAtom)).toBeTruthy();
+    expect(ctx.get(list.array).length).toBe(3);
+  })
+  
+  test('should accept only initState and key optionally', () => {
+    const ctx = createTestCtx()
+    const list = reatomLinkedList({
+      initState: [{ id: atom('1') }, { id: atom('2') }],
+      key: 'id',
+    });
+  
+    const track = ctx.subscribeTrack(atom((ctx) => [...ctx.spy(list.map).keys()]))
+  
+    expect(track.lastInput()).toBe(['1', '2'])
+  
+    ctx.get(list.map).get('1')?.id(ctx, '0')
+    expect(track.lastInput()).toBe(['0', '2'])
   })
 })

--- a/packages/primitives/src/reatomLinkedList.ts
+++ b/packages/primitives/src/reatomLinkedList.ts
@@ -257,12 +257,9 @@ const toArray = <T extends Rec>(
   return arr.length === prev?.length ? prev : arr
 }
 
-export const reatomLinkedList = <
-  Params extends any[],
-  Node extends Rec,
-  Key extends keyof Node = never,
->(
+export const reatomLinkedList = <Node extends Rec, Params extends any[] = [Node], Key extends keyof Node = never>(
   options:
+    | Array<Node>
     | ((ctx: Ctx, ...params: Params) => Node)
     | {
         create: (ctx: Ctx, ...params: Params) => Node

--- a/packages/primitives/src/reatomLinkedList.ts
+++ b/packages/primitives/src/reatomLinkedList.ts
@@ -257,7 +257,35 @@ const toArray = <T extends Rec>(
   return arr.length === prev?.length ? prev : arr
 }
 
-export const reatomLinkedList = <Node extends Rec, Params extends any[] = [Node], Key extends keyof Node = never>(
+export function reatomLinkedList<Node extends Rec, Params extends any[] = [Node], Key extends keyof Node = never>(
+  initState: Array<Node>,
+  name?: string
+): LinkedListAtom<Params, Node, Key>;
+
+export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
+  initState: ((ctx: Ctx, ...params: Params) => Node),
+  name?: string
+): LinkedListAtom<Params, Node, Key>;
+
+export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
+  initState: {
+    create: (ctx: Ctx, ...params: Params) => Node
+    initState?: Array<Node>
+    key?: Key
+  },
+  name?: string
+): LinkedListAtom<Params, Node, Key>;
+
+export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
+  initState: {
+    create?: (ctx: Ctx, ...params: Params) => Node,
+    initState: Array<Node>,
+    key?: Key
+  },
+  name?: string
+): LinkedListAtom<Params, Node, Key>;
+
+export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
   options:
     | Array<Node>
     | ((ctx: Ctx, ...params: Params) => Node)
@@ -272,7 +300,7 @@ export const reatomLinkedList = <Node extends Rec, Params extends any[] = [Node]
         key?: Key
       },
   name = __count('reatomLinkedList'),
-): LinkedListAtom<Params, Node, Key> => {
+): LinkedListAtom<Params, Node, Key> {
   const {
     create: userCreate,
     key = undefined,

--- a/packages/primitives/src/reatomLinkedList.ts
+++ b/packages/primitives/src/reatomLinkedList.ts
@@ -286,27 +286,42 @@ export function reatomLinkedList<Params extends any[], Node extends Rec, Key ext
 ): LinkedListAtom<Params, Node, Key>;
 
 export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
+  initSnapshot: {
+    create: (ctx: Ctx, ...params: Params) => Node,
+    initSnapshot?: Array<Params>,
+    key?: Key
+  },
+  name?: string
+): LinkedListAtom<Params, Node, Key>;
+
+export function reatomLinkedList<Params extends any[], Node extends Rec, Key extends keyof Node = never>(
   options:
     | Array<Node>
     | ((ctx: Ctx, ...params: Params) => Node)
     | {
-        create: (ctx: Ctx, ...params: Params) => Node
-        initState?: Array<Node>
-        key?: Key
-      }
+      create?: (ctx: Ctx, ...params: Params) => Node
+      initState?: Array<Node>
+      key?: Key
+    }
     | {
-        create: (ctx: Ctx, ...params: Params) => Node
-        initSnapshot?: Array<Params>
-        key?: Key
-      },
+      create: (ctx: Ctx, ...params: Params) => Node
+      initSnapshot?: Array<Params>
+      key?: Key
+    },
   name = __count('reatomLinkedList'),
 ): LinkedListAtom<Params, Node, Key> {
   const {
-    create: userCreate,
+    create: userCreate = (ctx: Ctx, ...params: Params) => params[0],
     key = undefined,
     ...restOptions
-  } = typeof options === 'function' ? { create: options } : options
-  const _name = name
+  } = typeof options === 'function' ? {
+    create: options
+  } : Array.isArray(options) ? {
+    create: (ctx: Ctx, ...params: Params) => params[0],
+    initState: options,
+  } : options;
+
+  const _name = name;
 
   const isLL = (node: Node): node is LLNode<Node> =>
     !!node && LL_NEXT in node && LL_PREV in node

--- a/packages/primitives/src/reatomMap.test.ts
+++ b/packages/primitives/src/reatomMap.test.ts
@@ -63,4 +63,14 @@ describe(`reatomMap`, () => {
 
     expect(ctx.get(mapAtom.sizeAtom)).toEqual(0)
   })
+
+  test(`should accept map constructor as initState`, () => {
+    const ctx = createCtx()
+  
+    let mapAtom = reatomMap(defaultMapEntries)
+    expect(ctx.get(mapAtom.sizeAtom)).toBe(3)
+  
+    mapAtom = reatomMap();
+    expect(ctx.get(mapAtom.sizeAtom)).toBe(0)
+  })
 })

--- a/packages/primitives/src/reatomMap.ts
+++ b/packages/primitives/src/reatomMap.ts
@@ -12,11 +12,15 @@ export interface MapAtom<Key, Value> extends AtomMut<Map<Key, Value>> {
   sizeAtom: Atom<number>
 }
 
+type FirstMapConstructorParam<Key, Value> = ConstructorParameters<typeof Map<Key, Value>>[0]
+
 export const reatomMap = <Key, Value>(
-  initState = new Map<Key, Value>(),
+  initState: Map<Key, Value> | FirstMapConstructorParam<Key, Value> = new Map<Key, Value>(),
   name?: string,
-): MapAtom<Key, Value> =>
-  atom(initState, name).pipe(
+): MapAtom<Key, Value> => {
+  const atomInitState = initState instanceof Map ? initState : new Map(initState);
+
+  return atom(atomInitState, name).pipe(
     withAssign((target, name) => {
       const getOrCreate = action((ctx, key: Key, value: Value) => {
         actions.set(ctx, key, value)
@@ -52,10 +56,11 @@ export const reatomMap = <Key, Value>(
           `${name}.delete`,
         ),
         clear: action((ctx) => target(ctx, new Map()), `${name}.clear`),
-        reset: action((ctx) => target(ctx, initState), `${name}.reset`),
-        sizeAtom: atom((ctx) => ctx.spy(target).size, `${name}.size`),
+        reset: action((ctx) => target(ctx, atomInitState), `${name}.reset`),
+        sizeAtom: atom(ctx =>  ctx.spy(target).size, `${name}.size`),
       }
 
       return actions
     }),
   )
+}

--- a/packages/primitives/src/reatomSet.test.ts
+++ b/packages/primitives/src/reatomSet.test.ts
@@ -1,130 +1,141 @@
-import { test, expect } from 'vitest'
+import { test, expect, describe } from 'vitest'
 import { createCtx } from '@reatom/core'
 import { reatomSet } from './reatomSet'
 
-test(`reatomSet. init`, () => {
-  const ctx = createCtx()
+describe('reatomSet', () => {
+  test(`init`, () => {
+    const ctx = createCtx()
 
-  expect(ctx.get(reatomSet(new Set([1, 2, 3])))).toEqual(new Set([1, 2, 3]))
-})
+    expect(ctx.get(reatomSet(new Set([1, 2, 3])))).toEqual(new Set([1, 2, 3]))
+  })
 
-test(`reatomSet. add`, () => {
-  const ctx = createCtx()
+  test(`add`, () => {
+    const ctx = createCtx()
 
-  expect(reatomSet(new Set([1, 2, 3])).add(ctx, 4)).toEqual(
-    new Set([1, 2, 3, 4]),
-  )
-})
+    expect(reatomSet(new Set([1, 2, 3])).add(ctx, 4)).toEqual(
+      new Set([1, 2, 3, 4]),
+    )
+  })
 
-test(`reatomSet. delete`, () => {
-  const ctx = createCtx()
+  test(`delete`, () => {
+    const ctx = createCtx()
 
-  expect(reatomSet(new Set([1, 2, 3])).delete(ctx, 3)).toEqual(new Set([1, 2]))
-})
+    expect(reatomSet(new Set([1, 2, 3])).delete(ctx, 3)).toEqual(new Set([1, 2]))
+  })
 
-test(`reatomSet. toggle`, () => {
-  const ctx = createCtx()
-  const a = reatomSet(new Set([1, 2, 3]))
+  test(`toggle`, () => {
+    const ctx = createCtx()
+    const a = reatomSet(new Set([1, 2, 3]))
 
-  expect(a.toggle(ctx, 3)).toEqual(new Set([1, 2]))
-  expect(a.toggle(ctx, 3)).toEqual(new Set([1, 2, 3]))
-})
+    expect(a.toggle(ctx, 3)).toEqual(new Set([1, 2]))
+    expect(a.toggle(ctx, 3)).toEqual(new Set([1, 2, 3]))
+  })
 
-test(`reatomSet. clear`, () => {
-  const ctx = createCtx()
+  test(`clear`, () => {
+    const ctx = createCtx()
 
-  expect(reatomSet(new Set([1, 2, 3])).clear(ctx)).toEqual(new Set())
-})
+    expect(reatomSet(new Set([1, 2, 3])).clear(ctx)).toEqual(new Set())
+  })
 
-test(`reatomSet. reset`, () => {
-  const ctx = createCtx()
-  const a = reatomSet(new Set([1, 2, 3]))
+  test(`reset`, () => {
+    const ctx = createCtx()
+    const a = reatomSet(new Set([1, 2, 3]))
 
-  expect(a.add(ctx, 4)).toEqual(new Set([1, 2, 3, 4]))
-  expect(a.reset(ctx)).toEqual(new Set([1, 2, 3]))
-})
+    expect(a.add(ctx, 4)).toEqual(new Set([1, 2, 3, 4]))
+    expect(a.reset(ctx)).toEqual(new Set([1, 2, 3]))
+  })
 
-test(`reatomSet. intersection`, () => {
-  const ctx = createCtx()
+  test(`intersection`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).intersection(ctx, new Set([2, 3, 4])),
-  ).toEqual(new Set([2, 3]))
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).intersection(ctx, new Set([2, 3, 4])),
+    ).toEqual(new Set([2, 3]))
+  })
 
-test(`reatomSet. union`, () => {
-  const ctx = createCtx()
+  test(`union`, () => {
+    const ctx = createCtx()
 
-  expect(reatomSet(new Set([1, 2, 3])).union(ctx, new Set([2, 3, 4]))).toEqual(
-    new Set([1, 2, 3, 4]),
-  )
-})
+    expect(reatomSet(new Set([1, 2, 3])).union(ctx, new Set([2, 3, 4]))).toEqual(
+      new Set([1, 2, 3, 4]),
+    )
+  })
 
-test(`reatomSet. difference`, () => {
-  const ctx = createCtx()
+  test(`difference`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).difference(ctx, new Set([2, 3, 4])),
-  ).toEqual(new Set([1]))
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).difference(ctx, new Set([2, 3, 4])),
+    ).toEqual(new Set([1]))
+  })
 
-test(`reatomSet. symmetricDifference`, () => {
-  const ctx = createCtx()
+  test(`symmetricDifference`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).symmetricDifference(ctx, new Set([2, 3, 4])),
-  ).toEqual(new Set([1, 4]))
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).symmetricDifference(ctx, new Set([2, 3, 4])),
+    ).toEqual(new Set([1, 4]))
+  })
 
-test(`reatomSet. isSubsetOf`, () => {
-  const ctx = createCtx()
+  test(`isSubsetOf`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).isSubsetOf(ctx, new Set([2, 3, 4])),
-  ).toBe(false)
-  expect(
-    reatomSet(new Set([1, 2, 3])).isSubsetOf(ctx, new Set([1, 2, 3])),
-  ).toBe(true)
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).isSubsetOf(ctx, new Set([2, 3, 4])),
+    ).toBe(false)
+    expect(
+      reatomSet(new Set([1, 2, 3])).isSubsetOf(ctx, new Set([1, 2, 3])),
+    ).toBe(true)
+  })
 
-test(`reatomSet. isSupersetOf`, () => {
-  const ctx = createCtx()
+  test(`isSupersetOf`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).isSupersetOf(ctx, new Set([2, 3, 4])),
-  ).toBe(false)
-  expect(
-    reatomSet(new Set([1, 2, 3])).isSupersetOf(ctx, new Set([1, 2, 3])),
-  ).toBe(true)
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).isSupersetOf(ctx, new Set([2, 3, 4])),
+    ).toBe(false)
+    expect(
+      reatomSet(new Set([1, 2, 3])).isSupersetOf(ctx, new Set([1, 2, 3])),
+    ).toBe(true)
+  })
 
-test(`reatomSet. isDisjointFrom`, () => {
-  const ctx = createCtx()
+  test(`isDisjointFrom`, () => {
+    const ctx = createCtx()
 
-  expect(
-    reatomSet(new Set([1, 2, 3])).isDisjointFrom(ctx, new Set([4, 5, 6])),
-  ).toBe(true)
-  expect(
-    reatomSet(new Set([1, 2, 3])).isDisjointFrom(ctx, new Set([3, 4, 5])),
-  ).toBe(false)
-})
+    expect(
+      reatomSet(new Set([1, 2, 3])).isDisjointFrom(ctx, new Set([4, 5, 6])),
+    ).toBe(true)
+    expect(
+      reatomSet(new Set([1, 2, 3])).isDisjointFrom(ctx, new Set([3, 4, 5])),
+    ).toBe(false)
+  })
 
-test(`reatomSet. size`, () => {
-  const ctx = createCtx()
+  test(`size`, () => {
+    const ctx = createCtx()
 
-  expect(reatomSet(new Set()).size(ctx)).toEqual(0)
-  expect(reatomSet(new Set([1, 2, 3])).size(ctx)).toEqual(3)
-})
+    expect(reatomSet(new Set()).size(ctx)).toEqual(0)
+    expect(reatomSet(new Set([1, 2, 3])).size(ctx)).toEqual(3)
+  })
 
-test(`reatomSet.sizeAtom`, () => {
-  const ctx = createCtx()
-  const a = reatomSet(new Set([1, 2, 3]))
+  test(`sizeAtom`, () => {
+    const ctx = createCtx()
+    const a = reatomSet(new Set([1, 2, 3]))
 
-  expect(ctx.get(a.sizeAtom)).toEqual(3)
-  a.add(ctx, 4)
-  expect(ctx.get(a.sizeAtom)).toEqual(4)
-  a.delete(ctx, 1)
-  expect(ctx.get(a.sizeAtom)).toEqual(3)
-  a.clear(ctx)
-  expect(ctx.get(a.sizeAtom)).toEqual(0)
+    expect(ctx.get(a.sizeAtom)).toEqual(3)
+    a.add(ctx, 4)
+    expect(ctx.get(a.sizeAtom)).toEqual(4)
+    a.delete(ctx, 1)
+    expect(ctx.get(a.sizeAtom)).toEqual(3)
+    a.clear(ctx)
+    expect(ctx.get(a.sizeAtom)).toEqual(0)
+  })
+
+  test(`should accept set constructor as initState`, () => {
+    const ctx = createCtx()
+    const a = reatomSet(new Set([1, 2, 3]))
+    expect(ctx.get(a.sizeAtom)).toBe(3)
+
+    const b = reatomSet()
+    expect(ctx.get(b.sizeAtom)).toBe(0)
+  })
 })

--- a/packages/primitives/src/reatomSet.ts
+++ b/packages/primitives/src/reatomSet.ts
@@ -32,11 +32,15 @@ interface ProposalSet<T> extends Set<T> {
   union(other: Set<T>): Set<T>
 }
 
+type FirstSetConstructorParam<T> = ConstructorParameters<typeof Set<T>>[0]
+
 export const reatomSet = <T>(
-  initState = new Set<T>(),
+  initState: Set<T> | FirstSetConstructorParam<T> = new Set<T>(),
   name?: string,
-): SetAtom<T> =>
-  atom(initState, name).pipe(
+): SetAtom<T> => {
+  const atomInitState = initState instanceof Set ? initState : new Set(initState);
+  
+  return atom(atomInitState, name).pipe(
     withAssign((target, name) => ({
       add: action(
         (ctx, el) =>
@@ -63,7 +67,7 @@ export const reatomSet = <T>(
           return new Set<T>()
         })
       }, `${name}.clear`),
-      reset: action((ctx) => target(ctx, initState), `${name}.reset`),
+      reset: action((ctx) => target(ctx, atomInitState), `${name}.reset`),
       intersection: action(
         (ctx, set) =>
           target(ctx, (prev) => (prev as ProposalSet<T>).intersection(set)),
@@ -105,3 +109,4 @@ export const reatomSet = <T>(
       sizeAtom: atom((ctx) => ctx.spy(target).size, `${name}.size`),
     })),
   )
+}


### PR DESCRIPTION
Allowing initialization like:
* `reatomLinkedList([atom(1), atom(2)])` , or
```ts
const list = reatomLinkedList({
  initState: [{ id: atom('1') }, { id: atom('2') }],
  key: 'id',
});
```
* `reatomMap([['key', 'value']])`, `reatomMap()` as empty map
* `reatomSet(['el1', 'el2'])`, `reatomSet()` as empty set