### PR TITLE
chore(eslint): add simple-import-sort plugin^12.1.1

### DIFF
--- a/examples/filters-logging/eslint.config.js
+++ b/examples/filters-logging/eslint.config.js
@@ -3,6 +3,7 @@ import globals from "globals"
 import reactHooks from "eslint-plugin-react-hooks"
 import reactRefresh from "eslint-plugin-react-refresh"
 import tseslint from "typescript-eslint"
+import simpleImportSort from "eslint-plugin-simple-import-sort"
 
 export default tseslint.config(
   { ignores: ["dist"] },
@@ -16,10 +17,13 @@ export default tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
+      "simple-import-sort": simpleImportSort,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "simple-import-sort/imports": "off",
+      "simple-import-sort/exports": "off",
     },
   },
 )

--- a/examples/filters-logging/eslint.config.js
+++ b/examples/filters-logging/eslint.config.js
@@ -22,8 +22,8 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      "simple-import-sort/imports": "off",
-      "simple-import-sort/exports": "off",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "yoctobundle": "*",
         "zx": "^8.3.2"
       },
+      "devDependencies": {
+        "eslint-plugin-simple-import-sort": "^12.1.1"
+      },
       "engines": {
         "npm": ">=10"
       }
@@ -4440,6 +4443,15 @@
         }
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
@@ -7950,8 +7962,8 @@
       "license": "MIT",
       "devDependencies": {
         "@observablehq/inspector": "^5.0.0",
-        "@reatom/framework": "*",
-        "@reatom/jsx": "*",
+        "@reatom/framework": "latest",
+        "@reatom/jsx": "latest",
         "@reatom/npm-zod": "^3.10.3",
         "jsondiffpatch": "^0.6.0",
         "vite": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "bugs": {
     "url": "https://github.com/artalar/reatom/issues"
   },
-  "homepage": "https://www.reatom.dev"
+  "homepage": "https://www.reatom.dev",
+  "devDependencies": {
+    "eslint-plugin-simple-import-sort": "^12.1.1"
+  }
 }


### PR DESCRIPTION
- https://github.com/artalar/reatom/issues/1074

## Changes
- Added `eslint-plugin-simple-import-sort@12.1.1` as dev dependency in `examples/eslint/filters-logging/eslint.config.js`
- Configured import sorting rules in ESLint config:
  ```js
  "simple-import-sort/imports": "off",
  "simple-import-sort/exports": "off"