### PR TITLE
fix(docs): iOS safari related scroll bugfix using svh css units

### DIFF
--- a/docs/src/components/landing/HeroSection.astro
+++ b/docs/src/components/landing/HeroSection.astro
@@ -111,6 +111,7 @@
   /* Hero Section */
   .hero-section {
     position: relative;
+    min-height: 100vh;
     min-height: 100svh;
     display: flex;
     align-items: center;

--- a/docs/src/components/landing/HeroSection.astro
+++ b/docs/src/components/landing/HeroSection.astro
@@ -338,6 +338,7 @@
   /* Scroll Indicator */
   .scroll-indicator {
     position: absolute;
+    top: calc(100vh - 4rem);
     top: calc(100svh - 4rem);
     left: 50%;
     transform: translateX(-50%);

--- a/docs/src/components/landing/HeroSection.astro
+++ b/docs/src/components/landing/HeroSection.astro
@@ -97,19 +97,21 @@
         </a>
       </div>
     </div>
+  
+  
   </div>
-
   <!-- Scroll Indicator -->
   <div class="scroll-indicator">
     <div class="scroll-arrow"></div>
   </div>
+
 </main>
 
 <style>
   /* Hero Section */
   .hero-section {
     position: relative;
-    min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -335,7 +337,7 @@
   /* Scroll Indicator */
   .scroll-indicator {
     position: absolute;
-    bottom: 2rem;
+    top: calc(100svh - 4rem);
     left: 50%;
     transform: translateX(-50%);
     z-index: 10;


### PR DESCRIPTION
1. scroll indicator position
2. prevent first block height jumping

https://github.com/user-attachments/assets/ab05e573-85e5-4f1a-8bfb-26b9a872119e

