### PR TITLE
docs: fix typo in Actions guide

### DIFF
--- a/docs/src/content/docs/start/actions.mdx
+++ b/docs/src/content/docs/start/actions.mdx
@@ -48,7 +48,7 @@ That's better!
 
 <Aside type="tip">
 If you use some LLM code assistant it will help you to write related names for you. 
-Also, we have an eslint plugin for this: [check out tooking](/start/tooking/).
+Also, we have an eslint plugin for this: [check out tooling](/start/tooling/).
 </Aside>
 
 However, each atom has a `.actions` method to bind and name related actions.


### PR DESCRIPTION
Hi! 👋
I was reading through the docs to get familiar with the library, and to find the differences between Jotai (the state solution I'm most familiar with) and Reatom. Very interesting stuff!

I noticed a small typo in the "Actions" guide, which also links to a non-existent "Tooking" guide.