### PR TITLE
Fix: typo in "tooking"

### DIFF
--- a/docs/src/content/docs/start/actions.mdx
+++ b/docs/src/content/docs/start/actions.mdx
@@ -48,7 +48,7 @@ That's better!
 
 <Aside type="tip">
 If you use some LLM code assistant it will help you to write related names for you. 
-Also, we have an eslint plugin for this: [check out tooking](/start/tooking/).
+Also, we have an eslint plugin for this: [check out tooling](/start/tooling/).
 </Aside>
 
 However, each atom has a `.actions` method to bind and name related actions.


### PR DESCRIPTION
Replace «tooking» with «tooling»