### PR TITLE
docs: remove unstable note

### DIFF
--- a/docs/src/content/docs/handbook/forms.md
+++ b/docs/src/content/docs/handbook/forms.md
@@ -5,8 +5,6 @@ description: All about Reatom forms
 
 This is a general form library with a simple focus and validation management.
 
-**The API is unstable and will be changed during minor updates!** Sorry for the semver mismatch, the first releases contained A LOT OF bugs and should have been released with an "experimental" tag. Until this note is present here, please don't consider the library stable.
-
 The form API is designed for the best type-safety and flexibility. Instead of setting up the form state with a single object, each field is created separately, giving you the ability to fine-tune each field perfectly. As the field and its meta statuses are stored in atoms, you can easily combine them, define hooks, and effects to describe any logic you need.
 
 The cherry on the cake is dynamic field management. You don't need to use weird string APIs like `form.${index}.property`. Instead, you can simply have a list of fields using [atomization](/handbook/atomization/).


### PR DESCRIPTION
Because forms already stable