### PR TITLE
V1000/support typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ build/
 .idea/
 .turbo
 .vercel
-*.tsbuildinfo
 tsbuild/
 autodocs/
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ build/
 .idea/
 .turbo
 .vercel
+*.tsbuildinfo
+tsbuild/
+autodocs/
 
 packages/**/package-lock.json
 packages/**/yarn.lock

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "reatom-workspace",
   "type": "module",
   "scripts": {
+    "postinstall": "pnpm --filter @reatom/core run build",
     "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && husky",
     "test": "vitest run",
     "release": "tsx ./tools/publish.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettify": "prettier --write */**/**/*.{js,ts,md}",
     "prettify:check": "prettier --check */**/**/*.{js,ts,md}",
     "prettify:watch": "onchange */**/**/*.{js,ts,md} -- prettier --write {{changed}}",
-    "autodocs": "typedoc"
+    "autodocs": "pnpm --filter @reatom/core --filter @reatom/jsx --filter @reatom/lit --filter @reatom/preact --filter @reatom/react --filter @reatom/vue exec tsc -b tsconfig.build.json && typedoc"
   },
   "engines": {
     "pnpm": ">=10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "reatom-workspace",
   "type": "module",
   "scripts": {
-    "postinstall": "pnpm --filter @reatom/core run build",
     "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && husky",
     "test": "vitest run",
     "release": "tsx ./tools/publish.ts",
@@ -12,7 +11,8 @@
     "update": "npx pnpm-check-updates -u",
     "prettify": "prettier --write */**/**/*.{js,ts,md}",
     "prettify:check": "prettier --check */**/**/*.{js,ts,md}",
-    "prettify:watch": "onchange */**/**/*.{js,ts,md} -- prettier --write {{changed}}"
+    "prettify:watch": "onchange */**/**/*.{js,ts,md} -- prettier --write {{changed}}",
+    "autodocs": "typedoc"
   },
   "engines": {
     "pnpm": ">=10",
@@ -30,6 +30,8 @@
     "husky": "catalog:",
     "prettier": "catalog:",
     "tsx": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "last 1 year"
   ],
   "scripts": {
-    "prepublishOnly": "tsc -p ./tsconfig.bundle.json && eslint src --fix && prettier src -w && pnpm run build",
+    "prepublishOnly": "tsc -b tsconfig.build.json && eslint src --fix && prettier src -w && pnpm run build",
     "build": "pnpm run test && pnpm run test:browser && yoctobundle",
     "test": "vitest run",
     "test:browser": "vitest run --config=vitest.browser.config.ts",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "declarationMap": true
+  }
+}

--- a/packages/core/tsconfig.bundle.json
+++ b/packages/core/tsconfig.bundle.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "declarationMap": true
-  },
-  "include": ["src"],
-  "exclude": ["build", "**/*.test.ts", "**/*.test.browser.ts", "**/*.test-d.ts", "src/test.ts"]
-}

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/packages/jsx/tsconfig.build.json
+++ b/packages/jsx/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "declarationMap": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "jsx": "preserve",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "hf",
+    "jsxImportSource": "@reatom/jsx",
+    "types": ["@vitest/browser/providers/playwright"],
+  },
+  "references": [
+    {"path": "../core/tsconfig.build.json"}
+  ]
+}

--- a/packages/jsx/typedoc.json
+++ b/packages/jsx/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/jsx/typedoc.json
+++ b/packages/jsx/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/packages/lit/tsconfig.build.json
+++ b/packages/lit/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "declarationMap": true
+  },
+  "references": [
+    {"path": "../core/tsconfig.build.json"}
+  ]
+}

--- a/packages/lit/typedoc.json
+++ b/packages/lit/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/lit/typedoc.json
+++ b/packages/lit/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/packages/preact/tsconfig.build.json
+++ b/packages/preact/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "declarationMap": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  },
+  "references": [
+    {"path": "../core/tsconfig.build.json"}
+  ]
+}

--- a/packages/preact/typedoc.json
+++ b/packages/preact/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/preact/typedoc.json
+++ b/packages/preact/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "declarationMap": true,
+    "jsx": "react-jsx"
+  },
+  "references": [
+    {"path": "../core/tsconfig.build.json"}
+  ]
+}

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "declarationMap": true
+  },
+  "references": [
+    {"path": "../core/tsconfig.build.json"}
+  ]
+}

--- a/packages/vue/typedoc.json
+++ b/packages/vue/typedoc.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
-	"tsconfig": "tsconfig.build.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.build.json"
 }

--- a/packages/vue/typedoc.json
+++ b/packages/vue/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"tsconfig": "tsconfig.build.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ catalogs:
     tsx:
       specifier: ^4.19.4
       version: 4.19.4
+    typedoc:
+      specifier: ^0.28.5
+      version: 0.28.5
+    typedoc-plugin-markdown:
+      specifier: ^4.6.4
+      version: 4.6.4
     typescript:
       specifier: ^5.8.3
       version: 5.8.3
@@ -121,7 +127,7 @@ importers:
     dependencies:
       '@commitlint/cli':
         specifier: 'catalog:'
-        version: 19.8.1(@types/node@24.0.1)(typescript@5.8.3)
+        version: 19.8.1(@types/node@24.0.3)(typescript@5.8.3)
       '@commitlint/config-conventional':
         specifier: 'catalog:'
         version: 19.8.1
@@ -133,7 +139,7 @@ importers:
         version: 1.0.0
       '@types/node':
         specifier: latest
-        version: 24.0.1
+        version: 24.0.3
       eslint:
         specifier: 'catalog:'
         version: 9.27.0(jiti@2.4.2)
@@ -152,6 +158,12 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.19.4
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.5(typescript@5.8.3)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.6.4(typedoc@0.28.5(typescript@5.8.3))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -160,7 +172,7 @@ importers:
         version: 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@24.0.1)(@vitest/browser@3.1.4)(terser@5.39.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/browser@3.1.4)(terser@5.39.2)
       yoctobundle:
         specifier: 'catalog:'
         version: 0.2.1(@babel/runtime@7.27.1)(rollup@4.41.1)(typescript@5.8.3)
@@ -197,7 +209,7 @@ importers:
         version: 1.0.0
       '@types/node':
         specifier: latest
-        version: 24.0.1
+        version: 24.0.3
       '@webreflection/signal':
         specifier: latest
         version: 2.1.2
@@ -221,7 +233,7 @@ importers:
         version: 6.13.7
       mol_wire_lib:
         specifier: latest
-        version: 1.0.1429
+        version: 1.0.1434
       nanostores:
         specifier: latest
         version: 1.0.1
@@ -291,7 +303,7 @@ importers:
     devDependencies:
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))(vitest@3.1.4)
+        version: 3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))(vitest@3.1.4)
       playwright:
         specifier: 'catalog:'
         version: 1.53.0
@@ -307,7 +319,7 @@ importers:
     devDependencies:
       vite:
         specifier: 'catalog:'
-        version: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+        version: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
 
   packages/preact:
     dependencies:
@@ -320,7 +332,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: 'catalog:'
-        version: 2.10.1(@babel/core@7.27.1)(preact@10.26.7)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+        version: 2.10.1(@babel/core@7.27.1)(preact@10.26.7)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
 
   packages/react:
     dependencies:
@@ -336,7 +348,7 @@ importers:
         version: 18.3.7(@types/react@18.3.22)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.5.0(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+        version: 4.5.0(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -922,6 +934,9 @@ packages:
     peerDependencies:
       tslib: ^2.3.1
 
+  '@gerrit0/mini-shiki@3.6.0':
+    resolution: {integrity: sha512-KaeJvPNofTEZR9EzVNp/GQzbQqkGfjiu6k3CXKvhVTX+8OoAKSX/k7qxLKOX3B0yh2XqVAc93rsOu48CGt2Qug==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1198,6 +1213,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/engine-oniguruma@3.6.0':
+    resolution: {integrity: sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==}
+
+  '@shikijs/langs@3.6.0':
+    resolution: {integrity: sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==}
+
+  '@shikijs/themes@3.6.0':
+    resolution: {integrity: sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==}
+
+  '@shikijs/types@3.6.0':
+    resolution: {integrity: sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1241,6 +1271,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1250,8 +1283,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.0.1':
-    resolution: {integrity: sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==}
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -2018,6 +2051,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   lit-element@3.3.3:
     resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
 
@@ -2072,6 +2108,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -2079,11 +2118,18 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -2173,8 +2219,8 @@ packages:
   mobx@6.13.7:
     resolution: {integrity: sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==}
 
-  mol_wire_lib@1.0.1429:
-    resolution: {integrity: sha512-j+uEFrRDm7qMszAwwwCQDzvFAB7mKFhVUaQBwaPhrXGKfMOURaBYlw8Kb2X/g6ZtzKFQjAq7+QwC8vw2MInlyg==}
+  mol_wire_lib@1.0.1434:
+    resolution: {integrity: sha512-9/HGLAiF+TmTSgITd8/WwZpid4CKEzKlGyPXshLs4N9rxwPO13FM/HqHOptNR4ikxS4z5WxnmMXeLnSGm8w+Ew==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -2301,6 +2347,10 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2552,6 +2602,19 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typedoc-plugin-markdown@4.6.4:
+    resolution: {integrity: sha512-AnbToFS1T1H+n40QbO2+i0wE6L+55rWnj7zxnM1r781+2gmhMF2dB6dzFpaylWLQYkbg4D1Y13sYnne/6qZwdw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
+  typedoc@0.28.5:
+    resolution: {integrity: sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
+
   typescript-eslint@8.32.1:
     resolution: {integrity: sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2563,6 +2626,9 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -2716,6 +2782,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2910,11 +2981,11 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@commitlint/cli@19.8.1(@types/node@24.0.1)(typescript@5.8.3)':
+  '@commitlint/cli@19.8.1(@types/node@24.0.3)(typescript@5.8.3)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@24.0.1)(typescript@5.8.3)
+      '@commitlint/load': 19.8.1(@types/node@24.0.3)(typescript@5.8.3)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.1
@@ -2961,7 +3032,7 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@24.0.1)(typescript@5.8.3)':
+  '@commitlint/load@19.8.1(@types/node@24.0.3)(typescript@5.8.3)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -2969,7 +3040,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.0.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.0.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3233,6 +3304,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@gerrit0/mini-shiki@3.6.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.6.0
+      '@shikijs/langs': 3.6.0
+      '@shikijs/themes': 3.6.0
+      '@shikijs/types': 3.6.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3304,18 +3383,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@preact/preset-vite@2.10.1(@babel/core@7.27.1)(preact@10.26.7)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))':
+  '@preact/preset-vite@2.10.1(@babel/core@7.27.1)(preact@10.26.7)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.27.1)
-      '@prefresh/vite': 2.4.7(preact@10.26.7)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+      '@prefresh/vite': 2.4.7(preact@10.26.7)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.27.1)
       debug: 4.4.1
       kolorist: 1.8.0
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
-      vite-prerender-plugin: 0.5.10(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
+      vite-prerender-plugin: 0.5.10(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -3330,7 +3409,7 @@ snapshots:
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.7(preact@10.26.7)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))':
+  '@prefresh/vite@2.4.7(preact@10.26.7)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))':
     dependencies:
       '@babel/core': 7.27.1
       '@prefresh/babel-plugin': 0.5.1
@@ -3338,7 +3417,7 @@ snapshots:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.26.7
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3456,6 +3535,26 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.1':
     optional: true
 
+  '@shikijs/engine-oniguruma@3.6.0':
+    dependencies:
+      '@shikijs/types': 3.6.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.6.0':
+    dependencies:
+      '@shikijs/types': 3.6.0
+
+  '@shikijs/themes@3.6.0':
+    dependencies:
+      '@shikijs/types': 3.6.0
+
+  '@shikijs/types@3.6.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@testing-library/dom@10.4.0':
@@ -3503,7 +3602,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3516,6 +3615,10 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -3524,7 +3627,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.0.1':
+  '@types/node@24.0.3':
     dependencies:
       undici-types: 7.8.0
 
@@ -3638,7 +3741,7 @@ snapshots:
     dependencies:
       valibot: 1.0.0-beta.12(typescript@5.8.3)
 
-  '@vitejs/plugin-react@4.5.0(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))':
+  '@vitejs/plugin-react@4.5.0(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.1)
@@ -3646,20 +3749,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))(vitest@3.1.4)':
+  '@vitest/browser@3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))(vitest@3.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
       '@vitest/utils': 3.1.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@24.0.1)(@vitest/browser@3.1.4)(terser@5.39.2)
+      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/browser@3.1.4)(terser@5.39.2)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.53.0
@@ -3676,13 +3779,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))':
+  '@vitest/mocker@3.1.4(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -3942,9 +4045,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@24.0.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.0.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
@@ -4361,6 +4464,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   lit-element@3.3.3:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.3.0
@@ -4413,11 +4520,22 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -4439,6 +4557,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.0.0: {}
 
   meow@12.1.1: {}
 
@@ -4594,7 +4714,7 @@ snapshots:
 
   mobx@6.13.7: {}
 
-  mol_wire_lib@1.0.1429: {}
+  mol_wire_lib@1.0.1434: {}
 
   mrmime@2.0.1: {}
 
@@ -4709,6 +4829,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -4957,6 +5079,19 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  typedoc-plugin-markdown@4.6.4(typedoc@0.28.5(typescript@5.8.3)):
+    dependencies:
+      typedoc: 0.28.5(typescript@5.8.3)
+
+  typedoc@0.28.5(typescript@5.8.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.6.0
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.8.3
+      yaml: 2.8.0
+
   typescript-eslint@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
@@ -4968,6 +5103,8 @@ snapshots:
       - supports-color
 
   typescript@5.8.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@7.8.0: {}
 
@@ -4993,13 +5130,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  vite-node@3.1.4(@types/node@24.0.1)(terser@5.39.2):
+  vite-node@3.1.4(@types/node@24.0.3)(terser@5.39.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5011,7 +5148,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-prerender-plugin@0.5.10(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2)):
+  vite-prerender-plugin@0.5.10(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.17
@@ -5019,22 +5156,22 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.4
       stack-trace: 1.0.0-pre2
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
 
-  vite@5.4.19(@types/node@24.0.1)(terser@5.39.2):
+  vite@5.4.19(@types/node@24.0.3)(terser@5.39.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.41.1
     optionalDependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       fsevents: 2.3.3
       terser: 5.39.2
 
-  vitest@3.1.4(@types/debug@4.1.12)(@types/node@24.0.1)(@vitest/browser@3.1.4)(terser@5.39.2):
+  vitest@3.1.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/browser@3.1.4)(terser@5.39.2):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))
+      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -5051,13 +5188,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@24.0.1)(terser@5.39.2)
-      vite-node: 3.1.4(@types/node@24.0.1)(terser@5.39.2)
+      vite: 5.4.19(@types/node@24.0.3)(terser@5.39.2)
+      vite-node: 3.1.4(@types/node@24.0.3)(terser@5.39.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.0.1
-      '@vitest/browser': 3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.1)(terser@5.39.2))(vitest@3.1.4)
+      '@types/node': 24.0.3
+      '@vitest/browser': 3.1.4(playwright@1.53.0)(vite@5.4.19(@types/node@24.0.3)(terser@5.39.2))(vitest@3.1.4)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5113,6 +5250,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,4 +62,6 @@ catalog:
   wonka: latest
   yoctobundle: ^0.2.1
   zod: ^3.25.17
+  typedoc: ^0.28.5
+  typedoc-plugin-markdown: ^4.6.4
   zx: ^8.5.4

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": "${configDir}/tsbuild",
+        "composite": true,
+        "paths": {
+            "@reatom/core": ["./packages/core/src/index.ts"]
+        }
+    },
+    "include": ["${configDir}/src"],
+    "exclude": [
+        "${configDir}/**/*.test.ts", 
+        "${configDir}/**/*.test.browser.ts", 
+        "${configDir}/**/*.test-d.ts", 
+        "${configDir}/src/test.ts",
+        "${configDir}/**/*.test.tsx", 
+        "${configDir}/**/*.bench.ts",
+    ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,20 +1,21 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "outDir": "${configDir}/tsbuild",
-        "composite": true,
-        "paths": {
-            "@reatom/core": ["./packages/core/src/index.ts"]
-        }
-    },
-    "include": ["${configDir}/src"],
-    "exclude": [
-        "${configDir}/**/*.test.ts", 
-        "${configDir}/**/*.test.browser.ts", 
-        "${configDir}/**/*.test-d.ts", 
-        "${configDir}/src/test.ts",
-        "${configDir}/**/*.test.tsx", 
-        "${configDir}/**/*.bench.ts",
-    ]
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "${configDir}/tsbuild",
+    "tsBuildInfoFile": "${configDir}/tsbuild/.tsbuildinfo",
+    "composite": true,
+    "paths": {
+      "@reatom/core": ["./packages/core/src/index.ts"]
+    }
+  },
+  "include": ["${configDir}/src"],
+  "exclude": [
+    "${configDir}/**/*.test.ts", 
+    "${configDir}/**/*.test.browser.ts", 
+    "${configDir}/**/*.test-d.ts", 
+    "${configDir}/src/test.ts",
+    "${configDir}/**/*.test.tsx", 
+    "${configDir}/**/*.bench.ts",
+  ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": [
+        "packages/core", 
+        "packages/lit", 
+        "packages/preact", 
+        "packages/react", 
+        "packages/jsx", 
+        "packages/vue"
+    ],
+	"name": "reatom",
+    "out": "./autodocs",
+	"entryPointStrategy": "packages",
+	"gitRemote": "origin",
+    "plugin": ["typedoc-plugin-markdown"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,16 +1,16 @@
 {
-	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": [
-        "packages/core", 
-        "packages/lit", 
-        "packages/preact", 
-        "packages/react", 
-        "packages/jsx", 
-        "packages/vue"
-    ],
-	"name": "reatom",
-    "out": "./autodocs",
-	"entryPointStrategy": "packages",
-	"gitRemote": "origin",
-    "plugin": ["typedoc-plugin-markdown"]
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "packages/core", 
+    "packages/lit", 
+    "packages/preact", 
+    "packages/react", 
+    "packages/jsx", 
+    "packages/vue"
+  ],
+  "name": "reatom",
+  "out": "./autodocs",
+  "entryPointStrategy": "packages",
+  "gitRemote": "origin",
+  "plugin": ["typedoc-plugin-markdown"]
 }


### PR DESCRIPTION
This PR introduces a new command: pnpm autodocs, which uses typedoc to generate markdown documentation into a dedicated autodocs folder. The folder is added to .gitignore, and it’s recommended to generate it in CI pipelines to ensure the documentation is always up to date.

The generated docs currently cover the following packages: core, jsx, lit, preact, react, and vue.

To avoid relying on prior manual type builds in the core package, I added tsconfig.build.json files with the composite flag to each included package. This enables referencing other packages in the monorepo using references, ensuring that TypeScript types are always up to date without explicit compilation—just as if they were part of a single project.

The tsbuild folders contain artifacts required by the tsc -b command. Without these compiled types, typedoc fails to function correctly.

