### PR TITLE
ci: add continuous preview release

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -5,14 +5,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  pull-requests: write
-
 env:
   PNPM_VERSION: '10.12.1'
-  NODE_VERSION: '22.13.1'
 
-# Cancel in-progress runs of this workflow if a new commit is pushed
 concurrency:
   group: continuous-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -20,9 +15,10 @@ concurrency:
 jobs:
   preview-release:
     name: 'Release preview'
-    # Valid conditions: PR events or pushes to default branch
     if: github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    container:
+      image: node:22.13.1-alpine
     timeout-minutes: 30
 
     steps:
@@ -33,11 +29,6 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -1,22 +1,29 @@
 name: Continuous Preview Release
 
 on:
+  push:
   pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
   pull-requests: write
+
+env:
+  PNPM_VERSION: '10.12.1'
+  NODE_VERSION: '22.13.1'
 
 # Cancel in-progress runs of this workflow if a new commit is pushed
 concurrency:
-  group: continuous-preview-${{ github.event.pull_request.number }}
+  group: continuous-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   preview-release:
-    timeout-minutes: 30
+    name: 'Release preview'
+    # Valid conditions: PR events or pushes to default branch
+    if: github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -25,12 +32,12 @@ jobs:
       - name: Pin & bootstrap pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.13.1
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -1,0 +1,42 @@
+name: Continuous Preview Release
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel in-progress runs of this workflow if a new commit is pushed
+concurrency:
+  group: continuous-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview-release:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Pin & bootstrap pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.1
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: npx turbo run build
+
+      - name: Publish packages
+        run: pnpm dlx pkg-pr-new publish './packages/*' --packageManager=pnpm --no-template


### PR DESCRIPTION
Closes #1065

### Overview
This PR introduces a new GitHub Actions workflow: `continuous-release.yml`.
The workflow runs on:
- Pushes to the default branch (aka merges to main)
- Pull request events

It automatically builds and publishes packages to `pkg.pr.new`'s registry. 

For pull requests, `pkg.pr.new` comments with installation URLs for packages, and updates the comments with every new commit.

Example `pkg.pr.new` PR comment:
<img width="965" height="713" alt="Screen Shot 2025-07-18 at 3 15 32 PM" src="https://github.com/user-attachments/assets/7abdd9d9-b19e-463b-a11b-2a6f80df6992" />

In the absence of pull requests, you can access package URLs by manually constructing them using this format:
```
https://pkg.pr.new/reatom/reatom/@reatom/<package-name>@<commit-hash>
```
Or browse published packages at: https://pkg.pr.new/~/reatom/reatom

#### Motivation
Reatom packages are typically released in batches. This workflow introduces a "continuous release" strategy by leveraging [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new), which allows:

- Sharing experimental builds immediately
- Publishing hotfixes without waiting for a full release cycle

### How It Works

#### Setup

In order to use pkg.pr.new, you must install the `pkg.pr.new` GitHub application on the repository: https://github.com/apps/pkg-pr-new 

#### Features
- Triggering: PR events and pushes to default branch
- Concurrency: Cancels in-progress runs on new commits to the same PR
- Environment:
  - OS: `ubuntu-latest`
  - Node.js: `22.13.1`
  - pnpm: `10.12.1`
- Steps:
  - Checkout code
  - Set up Node.js and pnpm
  - Install dependencies via `pnpm install`
  - Build packages using Turbo
  - Publish packages via `pnpm dlx pkg-pr-new`

### More Notes

Question: Should the push trigger be removed from the workflow? Since all changes are merged through pull requests, and those PRs already trigger the workflow, it may be redundant to run it again on pushing to main.

#### Notes & Considerations
- No Node.js caching: Skipped due to missing lockfile
- Versioning: Follows versions used in `lint.yml`, `test.yml`, and `package.json`
- StackBlitz preview: Disabled as it's not relevant for package publishing

#### Optional Enhancements 
- Add a pkg.pr.new badge to the README
- Conditionally publish only if lint/tests pass
(Note: skipped for now, as tests may be outdated, and we want to allow previews even if they fail)
- Use Turbo caching to cut build times further
(requires setting up credentials/secrets)
- Optimize by only building and publishing changed packages (reduces time by ~50% or ~40s per run, but additional scripting may make it less maintainable):
<details> 
<summary>Expand to view code snippet for changed package detection</summary>

```
set -euo pipefail
# Get packages changed vs upstream base and include dependents
npx turbo run build --filter=...[upstream/${{ github.base_ref }}...HEAD] --dry=json \
  | jq -r '.tasks[].directory' \
  | sort -u > changed-dirs.txt

if [ ! -s changed-dirs.txt ]; then
  echo "paths=" >> "$GITHUB_OUTPUT"
  echo "No changed packages."
else
  CHANGED_PATHS=$(sed -e 's|^|./|' changed-dirs.txt | xargs)
  echo "paths=$CHANGED_PATHS" >> "$GITHUB_OUTPUT"
  echo "Changed paths: $CHANGED_PATHS"
fi
```

</details>