### PR TITLE
fix(@reatom/vue): import unexisting RefSymbol

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -25,7 +25,6 @@
   },
   "peerDependencies": {
     "@reatom/core": "workspace:^",
-    "@vue/reactivity": "^3.5.16",
     "vue": "^3.5.0"
   },
   "author": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@reatom/core": "workspace:^",
-    "vue": "^3.5.0"
+    "vue": "^3.5.17"
   },
   "author": {
     "name": "krulod",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,9 +7,8 @@ import {
   STACK,
   wrap,
 } from '@reatom/core'
-import { RefSymbol } from '@vue/reactivity'
 import type { App, Ref } from 'vue'
-import { inject, onScopeDispose, ref } from 'vue'
+import { inject, onScopeDispose, customRef } from 'vue'
 
 const ReatomContextKey = 'ReatomContextKey'
 
@@ -51,19 +50,27 @@ export function reatomRef<T>(
   // TODO fix type inference
   if (!isAtom(target)) throw 42
 
-  const vueState = ref()
+  let trigger: () => void
 
-  onScopeDispose(target.subscribe((state) => (vueState.value = state)))
+  const ref = customRef<T>((track, _trigger) => {
+    trigger = _trigger
 
-  return {
-    get value() {
-      return vueState.value
-    },
-    set value(next) {
-      // @ts-expect-error
-      target.set(next)
-    },
-    // @ts-ignore TODO
-    [RefSymbol]: true,
-  }
+    return {
+      get() {
+        track()
+        return target()
+      },
+      set(next) {
+        // @ts-expect-error
+        target.set(next)
+        _trigger()
+      },
+    }
+  })
+
+  const unsubscribe = target.subscribe(() => trigger())
+
+  onScopeDispose(unsubscribe)
+
+  return ref
 }


### PR DESCRIPTION
### Motivation:
Fixes #1170

@reatom/vue imports unexisting RefSymbol from @vue/reactivity which breaks a project build when it's used

### Modifications:
 - RefSymbol import was removed
 - reatomRef implementation was updated with using customRef
 - @vue/reactivity dependency was removed as unused