### PR TITLE
feat: add wip reatomRouteLink model

### DIFF
--- a/packages/core/src/web/route-link.test.browser.ts
+++ b/packages/core/src/web/route-link.test.browser.ts
@@ -1,0 +1,30 @@
+import { beforeEach, expect, test } from "vitest"
+
+import { reatomRoute } from "./route"
+import { reatomRouteLink } from "./route-link"
+
+beforeEach(() => {
+  if (window.location.pathname !== '/') {
+    window.history.replaceState({}, '', '/')
+  }
+})
+
+test('route link active state', () => {
+  const route = reatomRoute('profiles/:profileId/posts/:postId?')
+  
+  const routeLink = reatomRouteLink({ 
+    route, 
+    elementRef: document.createElement('a'),
+    params: { profileId: '123', postId: '456' },
+    activeOptions: { exact: true }
+  })
+
+  route.go({ profileId: '123', postId: '456' })
+  expect(routeLink.active()).toBe(true)
+
+  route.go({ profileId: '123' })
+  expect(routeLink.active()).toBe(false)
+
+  routeLink.activeOptions.merge({ exact: false })
+  expect(routeLink.active()).toBe(true)
+})

--- a/packages/core/src/web/route-link.test.browser.ts
+++ b/packages/core/src/web/route-link.test.browser.ts
@@ -1,5 +1,8 @@
-import { beforeEach, expect, test } from "vitest"
+import { subscribe, test } from "test"
+import { beforeEach, describe, expect } from "vitest"
 
+import { wrap } from "../methods"
+import { sleep } from "../utils"
 import { reatomRoute } from "./route"
 import { reatomRouteLink } from "./route-link"
 
@@ -27,4 +30,37 @@ test('route link active state', () => {
 
   routeLink.activeOptions.merge({ exact: false })
   expect(routeLink.active()).toBe(true)
+})
+
+describe('route link preloading', () => {
+  test('on render', async () => {
+    const route = reatomRoute('users/:id')
+
+    const routeLink = reatomRouteLink({ 
+      route, 
+      preload: 'render',
+      disabled: true,
+      elementRef: document.createElement('a'),
+      params: { id: '123' },
+      activeOptions: { exact: true }
+    })
+
+    const track = subscribe(routeLink.route.loader.data)
+
+    expect(track).toBeCalledWith(undefined)
+
+    const preload = routeLink.preload()
+    expect(preload.type === 'render').toBe(true)
+    if(preload.type !== 'render') return
+
+    wrap(preload.render())
+    await wrap(sleep())
+
+    expect(track).toBeCalledTimes(1)
+
+    routeLink.disabled.setTrue()
+    await wrap(sleep())
+
+    expect(track).toBeCalledTimes(2)
+  })
 })

--- a/packages/core/src/web/route-link.ts
+++ b/packages/core/src/web/route-link.ts
@@ -1,24 +1,56 @@
-import { action, atom, computed, withParams } from '../core'
+import { action, atom, computed, named, withParams } from '../core'
 import { abortVar, effect, take, wrap } from '../methods'
 import { withAbort, withMemo } from '../mixins'
-import { noop, sleep, throwAbort } from '../utils'
-import type { RouteAtom } from './route'
+import { reatomRecord } from '../primitives'
+import { noop, type Plain, type Rec,sleep, throwAbort } from '../utils'
+import {
+  type MaybeVoid,
+  type PathKeys,
+  type RouteAtom,
+} from './route'
+import { urlAtom } from './url'
 
 export type RouteLinkPreload = 'intent' | 'render' | 'viewport' | 'none'
 
 export interface RouterLinkActiveOptions {
   exact?: boolean
+  includeSearch?: boolean
 }
 
-export interface RouteLinkOptions {
-  route: RouteAtom
+export interface RouteLinkOptions<
+  Path extends string,
+  Params extends PathKeys<Path>,
+  Search extends Rec<string>,
+  Payload = Plain<Params & Search>,
+  InputParams = Params,
+  InputSearch = Search,
+> {
+  route: RouteAtom<Path, Params, Search, Payload, InputParams, InputSearch>
+  params: MaybeVoid<InputParams & InputSearch>
   elementRef: Element
   preload?: RouteLinkPreload
   disabled?: boolean
   activeOptions?: RouterLinkActiveOptions
 }
 
-export const reatomRouteLink = (options: RouteLinkOptions, name: string) => {
+export const reatomRouteLink = <
+  Path extends string,
+  Params extends PathKeys<Path>,
+  Search extends Rec<string>,
+  Payload,
+  InputParams,
+  InputSearch,
+>(
+  options: RouteLinkOptions<
+    Path,
+    Params,
+    Search,
+    Payload,
+    InputParams,
+    InputSearch
+  >,
+  name = named('routeLink'),
+) => {
   const { route } = options
 
   const createPreload = (type: RouteLinkPreload) => {
@@ -28,12 +60,12 @@ export const reatomRouteLink = (options: RouteLinkOptions, name: string) => {
 
         await wrap(sleep(50))
 
-        route.loader().catch(noop)
-      }, `${name}._mouseEnter`).extend(withAbort())
+        if (!disabled()) route.loader().catch(noop)
+      }, `${name}._startIntent`).extend(withAbort())
 
       const cancelIntent = action(() => {
         if (!disabled()) startIntent.abort()
-      }, `${name}._mouseLeave`)
+      }, `${name}._cancelIntent`)
 
       return {
         type,
@@ -86,17 +118,51 @@ export const reatomRouteLink = (options: RouteLinkOptions, name: string) => {
     withAbort(),
   )
 
+  const params = atom(options.params, `${name}._params`)
   const elementRef = atom(options.elementRef, `${name}._elementRef`)
   const disabled = atom(options.disabled || false, `${name}._disabled`)
 
-  const activeOptions = atom(
+  const activeOptions = reatomRecord(
     options.activeOptions ?? {},
     `${name}._activeOptions`,
   ).extend(withMemo())
 
   const active = computed(() => {
-    const { exact = false } = activeOptions()
-    return exact ? route.exact() : route() !== null
+    const currentUrl = urlAtom()
+    const targetUrl = new URL(route.path(params()), currentUrl)
+    const { exact = false, includeSearch = false } = activeOptions()
+
+    const currentPathname = stripTrailingSlash(targetUrl.pathname)
+    const targetPathname = stripTrailingSlash(currentUrl.pathname)
+
+    if (exact) {
+      if (currentPathname !== targetPathname) {
+        return false
+      }
+    } else {
+      if (
+        !currentPathname.startsWith(targetPathname) ||
+        !(
+          currentPathname.length === targetPathname.length ||
+          currentPathname[targetPathname.length] === '/'
+        )
+      )
+        return false
+    }
+
+    if (includeSearch) {
+      for (const [key, value] of targetUrl.searchParams.entries()) {
+        const paramEqual = currentUrl.searchParams.get(key) !== value
+
+        if (exact) {
+          if (!paramEqual) return false
+        } else {
+          if (paramEqual) return true
+        }
+      }
+    }
+
+    return true
   }, `${name}._active`)
 
   return {
@@ -104,7 +170,11 @@ export const reatomRouteLink = (options: RouteLinkOptions, name: string) => {
     preload,
     disabled,
     elementRef,
+    params,
     activeOptions,
     active,
   }
 }
+
+const stripTrailingSlash = (str: string) =>
+  str.endsWith('/') && str !== '/' ? str.slice(0, -1) : str

--- a/packages/core/src/web/route-link.ts
+++ b/packages/core/src/web/route-link.ts
@@ -1,13 +1,9 @@
 import { action, atom, computed, named, withParams } from '../core'
 import { abortVar, effect, take, wrap } from '../methods'
 import { withAbort, withMemo } from '../mixins'
-import { reatomRecord } from '../primitives'
-import { noop, type Plain, type Rec,sleep, throwAbort } from '../utils'
-import {
-  type MaybeVoid,
-  type PathKeys,
-  type RouteAtom,
-} from './route'
+import { reatomBoolean, reatomRecord } from '../primitives'
+import { noop, sleep, throwAbort } from '../utils'
+import { type RouteLoader } from './route'
 import { urlAtom } from './url'
 
 export type RouteLinkPreload = 'intent' | 'render' | 'viewport' | 'none'
@@ -17,16 +13,14 @@ export interface RouterLinkActiveOptions {
   includeSearch?: boolean
 }
 
-export interface RouteLinkOptions<
-  Path extends string,
-  Params extends PathKeys<Path>,
-  Search extends Rec<string>,
-  Payload = Plain<Params & Search>,
-  InputParams = Params,
-  InputSearch = Search,
-> {
-  route: RouteAtom<Path, Params, Search, Payload, InputParams, InputSearch>
-  params: MaybeVoid<InputParams & InputSearch>
+interface RouterLikeAtom<Params> {
+  path: (params: Params) => string
+  loader: RouteLoader<any>
+}
+
+export interface RouteLinkOptions<Params, RouteAtom extends RouterLikeAtom<Params>> {
+  route: RouteAtom
+  params: Params
   elementRef: Element
   preload?: RouteLinkPreload
   disabled?: boolean
@@ -34,21 +28,10 @@ export interface RouteLinkOptions<
 }
 
 export const reatomRouteLink = <
-  Path extends string,
-  Params extends PathKeys<Path>,
-  Search extends Rec<string>,
-  Payload,
-  InputParams,
-  InputSearch,
+  Params,
+  RouteAtom extends RouterLikeAtom<Params>
 >(
-  options: RouteLinkOptions<
-    Path,
-    Params,
-    Search,
-    Payload,
-    InputParams,
-    InputSearch
-  >,
+  options: RouteLinkOptions<Params, RouteAtom>,
   name = named('routeLink'),
 ) => {
   const { route } = options
@@ -120,7 +103,7 @@ export const reatomRouteLink = <
 
   const params = atom(options.params, `${name}._params`)
   const elementRef = atom(options.elementRef, `${name}._elementRef`)
-  const disabled = atom(options.disabled || false, `${name}._disabled`)
+  const disabled = reatomBoolean(options.disabled || false, `${name}._disabled`)
 
   const activeOptions = reatomRecord(
     options.activeOptions ?? {},

--- a/packages/core/src/web/route-link.ts
+++ b/packages/core/src/web/route-link.ts
@@ -1,0 +1,110 @@
+import { action, atom, computed, withParams } from '../core'
+import { abortVar, effect, take, wrap } from '../methods'
+import { withAbort, withMemo } from '../mixins'
+import { noop, sleep, throwAbort } from '../utils'
+import type { RouteAtom } from './route'
+
+export type RouteLinkPreload = 'intent' | 'render' | 'viewport' | 'none'
+
+export interface RouterLinkActiveOptions {
+  exact?: boolean
+}
+
+export interface RouteLinkOptions {
+  route: RouteAtom
+  elementRef: Element
+  preload?: RouteLinkPreload
+  disabled?: boolean
+  activeOptions?: RouterLinkActiveOptions
+}
+
+export const reatomRouteLink = (options: RouteLinkOptions, name: string) => {
+  const { route } = options
+
+  const createPreload = (type: RouteLinkPreload) => {
+    if (type === 'intent') {
+      const startIntent = action(async () => {
+        if (disabled()) return
+
+        await wrap(sleep(50))
+
+        route.loader().catch(noop)
+      }, `${name}._mouseEnter`).extend(withAbort())
+
+      const cancelIntent = action(() => {
+        if (!disabled()) startIntent.abort()
+      }, `${name}._mouseLeave`)
+
+      return {
+        type,
+        mouseEnter: startIntent,
+        mouseLeave: cancelIntent,
+        touchStart: startIntent,
+        focus: startIntent,
+        blur: cancelIntent,
+      }
+    } else if (type === 'render') {
+      return {
+        type,
+        render: action(async () => {
+          await wrap(take(disabled, (disabled) => !disabled || throwAbort()))
+          route.loader().catch(noop)
+        }).extend(withAbort()),
+      }
+    } else if (type === 'viewport') {
+      effect(() => {
+        if (disabled()) return
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            for (const entry of entries) {
+              if (!entry.isIntersecting) continue
+
+              route.loader().catch(noop)
+              observer.disconnect()
+            }
+          },
+          {
+            rootMargin: '100px',
+          },
+        )
+
+        observer.observe(elementRef())
+
+        abortVar.subscribeAbort(observer.disconnect)
+      }, `${name}._intersectionObserver`)
+
+      return { type }
+    } else return { type }
+  }
+
+  const preload = atom(
+    createPreload(options.preload || 'none'),
+    `${name}._preload`,
+  ).extend(
+    withParams((preload: RouteLinkPreload) => createPreload(preload)),
+    withAbort(),
+  )
+
+  const elementRef = atom(options.elementRef, `${name}._elementRef`)
+  const disabled = atom(options.disabled || false, `${name}._disabled`)
+
+  const activeOptions = atom(
+    options.activeOptions ?? {},
+    `${name}._activeOptions`,
+  ).extend(withMemo())
+
+  const active = computed(() => {
+    const { exact = false } = activeOptions()
+    return exact ? route.exact() : route() !== null
+  }, `${name}._active`)
+
+  return {
+    route,
+    preload,
+    disabled,
+    elementRef,
+    activeOptions,
+    active,
+  }
+}

--- a/packages/core/src/web/route.test.browser.ts
+++ b/packages/core/src/web/route.test.browser.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, expectTypeOf, test, vi } from 'test'
-import z from 'zod'
+import z from 'zod/v4'
 
 import { computed } from '../core'
 import { effect, wrap } from '../methods'
@@ -187,23 +187,61 @@ test('route chainable functionality', async () => {
 })
 
 test('route typed params', () => {
-  {
-    // @ts-expect-error - test
-    const catalogRoute = reatomRoute({
-      path: 'catalog/:id',
-      params: z.object({ /* mistake -> */ ib: z.number() }),
-    })
-  }
+  // @ts-expect-error - mistmatch between path parameter declaration and the actual schema
+  reatomRoute({
+    path: 'catalog/:id',
+    params: z.object({ ib: z.string() }),
+  })
 
-  const catalogRoute = reatomRoute({
+  // @ts-expect-error - usage of pure number validator
+  reatomRoute({
     path: 'catalog/:id',
     params: z.object({ id: z.number() }),
   })
 
-  // @ts-expect-error - test
-  expect(() => catalogRoute.go({ id: '42' })).toThrow()
+  const catalogRoute = reatomRoute({
+    path: 'catalog/:id',
+    params: z.object({ id: z.coerce.number() }),
+  })
 
+  expect(() => catalogRoute.go({ id: '42' })).not.toThrow()
   expect(catalogRoute.go({ id: 42 }).pathname).toBe('/catalog/42')
+  expect(catalogRoute()).toEqual({ id: 42 })
+})
+
+test('route typed search params', () => {
+  // @ts-expect-error usage of pure number validator
+  reatomRoute({
+    path: 'catalog/:id',
+    search: z.object({ search: z.number() }),
+  })
+
+  // @ts-expect-error usage of number validator with string-compatible validator together
+  reatomRoute({
+    path: 'catalog/:id',
+    search: z.object({ search: z.string(), number: z.number() }),
+  })
+
+  reatomRoute({
+    path: 'catalog/:id',
+    search: z.object({ search: z.string().optional() }),
+  })
+
+  const route = reatomRoute({
+    path: 'catalog/:id',
+    search: z.object({ 
+      search: z.coerce.number().optional(),
+      other: z.string()
+    }),
+  })
+
+  expect(() => route.go({ id: '42', search: { search: 42 }, other: 'empty' })).toThrow()
+
+  route.go({ id: '42', search: new Date(), other: 'empty'  })
+  expect(route()?.search).toBeTypeOf('number')
+
+  // @ts-expect-error missing required parameter `other`
+  expect(() => route.go({ id: '42', search: 123 })).toThrow()
 })
 
 test('route default loader', async () => {
@@ -390,7 +428,7 @@ test('params collision', async () => {
 
   const liberalRoute = reatomRoute({
     path: 'liberalRoute/:id',
-    search: z.record(z.string()),
+    search: z.record(z.string(), z.string()),
   })
 
   const expectedId = '42'

--- a/packages/core/src/web/route.ts
+++ b/packages/core/src/web/route.ts
@@ -26,12 +26,18 @@ export type PathParams<Path extends string = string> =
         ? PathParams<Rest>
         : {}
 
-export type PathKeys<Path extends string> = Record<keyof PathParams<Path>, any>
+export type PathKeys<Path extends string> = Record<keyof PathParams<Path>, unknown>
+export type SearchKeys = Record<string, unknown>
+
+type IsNever<T> = [T] extends [never] ? true : false;
+
+type ParamsStringCompatible<B, Success, Error extends string> = 
+  IsNever<{ [K in keyof B]-?: IsNever<B[K] & string> extends true ? K : never }[keyof B]> extends true ? Success : Error;
 
 export interface RouteOptions<
   Path extends string = '',
   Params extends PathKeys<Path> = PathParams<Path>,
-  Search extends Partial<Rec<string>> = {},
+  Search extends SearchKeys = {},
   ParamsOutput = Params,
   SearchOutput = Search,
   LoaderParams = Plain<ParamsOutput & SearchOutput>,
@@ -39,9 +45,9 @@ export interface RouteOptions<
 > {
   path?: Path
 
-  params?: StandardSchemaV1<Params, ParamsOutput>
+  params?: ParamsStringCompatible<Params, StandardSchemaV1<Params, ParamsOutput>, 'ERROR: You can only use string-compatible parsers for path params'>
 
-  search?: StandardSchemaV1<Search, SearchOutput>
+  search?: ParamsStringCompatible<Search, StandardSchemaV1<Search, SearchOutput>, 'ERROR: You can only use string-compatible parsers for search params'>
 
   loader?: (params: LoaderParams) => Promise<Payload>
 }
@@ -98,7 +104,7 @@ export interface RouteMixin<
   reatomRoute<
     SubPath extends string = '',
     SubParams extends PathKeys<SubPath> = PathParams<SubPath>,
-    SubSearch extends Partial<Rec<string>> = {},
+    SubSearch extends SearchKeys = {},
     SubParamsOutput = SubParams,
     SubSearchOutput = SubSearch,
     LoaderParams = Plain<Params & SubParamsOutput & SubSearchOutput>,
@@ -128,7 +134,7 @@ export interface RouteMixin<
   route: this['reatomRoute']
 }
 
-function assertPromise<T>(value: T): asserts value is Exclude<T, Promise<any>> {
+function assertNotPromise<T>(value: T): asserts value is Exclude<T, Promise<any>> {
   if (value instanceof Promise) {
     throw new Error('Async params validation is not supported')
   }
@@ -155,7 +161,7 @@ export interface RouteLoader<Params extends Rec = Rec, Payload = any>
 export interface RouteAtom<
   Path extends string = string,
   Params extends PathKeys<Path> = PathParams<Path>,
-  Search extends Rec<string> = {},
+  Search extends SearchKeys = {},
   Payload = Plain<Params & Search>,
   InputParams = Params,
   InputSearch = Search,

--- a/packages/core/src/web/route.ts
+++ b/packages/core/src/web/route.ts
@@ -13,7 +13,7 @@ import type { Action, Computed } from '../core'
 import { action, computed, ReatomError } from '../core'
 import { urlAtom } from './url'
 
-type MaybeVoid<T> = {} extends T ? T | void : T
+export type MaybeVoid<T> = {} extends T ? T | void : T
 
 export type PathParams<Path extends string = string> =
   Path extends `:${infer Param}/${infer Rest}`

--- a/packages/core/src/web/route.ts
+++ b/packages/core/src/web/route.ts
@@ -130,14 +130,14 @@ export interface RouteMixin<
 
 function assertPromise<T>(value: T): asserts value is Exclude<T, Promise<any>> {
   if (value instanceof Promise) {
-    throw new Error('Async search validation is not supported')
+    throw new Error('Async params validation is not supported')
   }
 }
 
 const validate = (schema: StandardSchemaV1<any>, params: any, name: string) => {
   const validation = schema['~standard'].validate(params)
 
-  assertPromise(validation)
+  assertNotPromise(validation)
 
   if (validation.issues) {
     throw new Error(
@@ -308,7 +308,7 @@ const createRouteFactory = (
     const go = action((params: void | any, replace = false) => {
       const newPath = getPath(params)
 
-      return urlAtom.set((url) => new URL(newPath, url), replace)
+      return urlAtom.go(newPath, replace)
     }, `${name}.go`)
 
     const routeAtom = computed((state?: null | Rec): null | Rec => {


### PR DESCRIPTION
* Deprecate `parentRoute.route` syntax in favor of `parentRoute.reatomRoute`
* Framework agnostic `reatomRouteLink` with some encapsulated links logic like preload, active state, etc