### PR TITLE
add empty line for hightlights

### DIFF
--- a/docs/src/content/docs/start/actions.mdx
+++ b/docs/src/content/docs/start/actions.mdx
@@ -89,6 +89,7 @@ import { reatomComponent } from '@reatom/react'
 import { list } from './model'
 
 const Paging = reatomComponent(() => {
+  
   const [page, setPage] = React.useState(1)
 
   React.useEffect(() => {


### PR DESCRIPTION
hightlights are not part of the code, so we need to add empty line for the "label" to be shown

META: fixes #1205