### PR TITLE
Prototype reatomRoute exactRender

### DIFF
--- a/packages/core/src/routing/route.test.browser.ts
+++ b/packages/core/src/routing/route.test.browser.ts
@@ -510,3 +510,24 @@ test('loader data types', async () => {
     expectTypeOf(status.data).toExtend<number>()
   }
 })
+
+test('exactOnly should not render on children', async () => {
+  const rootRoute = reatomRoute({
+    path: '',
+    exactOnly: true,
+    render() {
+      return true
+    },
+  })
+  const childRoute = reatomRoute('child')
+
+  rootRoute.go()
+  await wrap(sleep())
+  expect(rootRoute.exact()).toBe(true)
+  expect(rootRoute.render()).toBeTruthy()
+
+  childRoute.go()
+  await wrap(sleep())
+  expect(rootRoute.exact()).toBe(false)
+  expect(rootRoute.render()).toBeFalsy()
+})

--- a/packages/core/src/routing/route.test.browser.ts
+++ b/packages/core/src/routing/route.test.browser.ts
@@ -512,22 +512,39 @@ test('loader data types', async () => {
 })
 
 test('exactOnly should not render on children', async () => {
-  const rootRoute = reatomRoute({
-    path: '',
+  const parentRoute = reatomRoute({
+    path: 'project',
     exactOnly: true,
     render() {
       return true
     },
   })
-  const childRoute = reatomRoute('child')
 
-  rootRoute.go()
+  urlAtom.go('/project/child')
   await wrap(sleep())
-  expect(rootRoute.exact()).toBe(true)
-  expect(rootRoute.render()).toBeTruthy()
+  expect(parentRoute.render()).toBeFalsy()
+})
+
+test('exactOnly should not affect children', async () => {
+  const parentRoute = reatomRoute({
+    path: 'project',
+    exactOnly: true,
+    render() {
+      return true
+    },
+  })
+  const childRoute = parentRoute.reatomRoute({
+    path: 'child',
+
+    render() {
+      return true
+    },
+  })
 
   childRoute.go()
   await wrap(sleep())
-  expect(rootRoute.exact()).toBe(false)
-  expect(rootRoute.render()).toBeFalsy()
+  expect(parentRoute.render()).toBeFalsy()
+  expect(parentRoute.match()).toBeTruthy()
+  expect(childRoute.render()).toBeTruthy()
+  expect(childRoute.match()).toBeTruthy()
 })

--- a/packages/core/src/routing/route.test.browser.ts
+++ b/packages/core/src/routing/route.test.browser.ts
@@ -511,10 +511,10 @@ test('loader data types', async () => {
   }
 })
 
-test('exactOnly should not render on children', async () => {
+test('exactRender should not render on children match', async () => {
   const parentRoute = reatomRoute({
     path: 'project',
-    exactOnly: true,
+    exactRender: true,
     render() {
       return true
     },
@@ -525,10 +525,10 @@ test('exactOnly should not render on children', async () => {
   expect(parentRoute.render()).toBeFalsy()
 })
 
-test('exactOnly should not affect children', async () => {
+test('exactRender should not affect children', async () => {
   const parentRoute = reatomRoute({
     path: 'project',
-    exactOnly: true,
+    exactRender: true,
     render() {
       return true
     },

--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -125,6 +125,13 @@ export interface RouteOptions<
   path?: Path
 
   /**
+   * Make `path` matches only exact matches
+   * 
+   * @see {RouteExt.exact}
+   */
+  exactOnly?: boolean,
+
+  /**
    * Schema to validate and transform path parameters. Uses Standard Schema
    * (compatible with Zod, Valibot, etc.).
    *
@@ -538,6 +545,7 @@ const createRouteFactory = (parent: RouteAtom | UrlAtom) => {
       search: searchSchema,
       loader: optionsLoader = identity,
       render: renderFn,
+      exactOnly = false
     } = options
 
     if (subPath.startsWith('/')) {
@@ -739,7 +747,7 @@ const createRouteFactory = (parent: RouteAtom | UrlAtom) => {
       }, `${name}._outlet`)
 
       const render = computed(() => {
-        return renderFn && match() ? renderFn({ outlet }) : null
+        return renderFn && (exactOnly ? exact() : match()) ? renderFn({ outlet }) : null
       }, `${name}._render`)
 
       return {

--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -124,12 +124,6 @@ export interface RouteOptions<
    */
   path?: Path
 
-  /**
-   * Make `path` matches only exact matches
-   * 
-   * @see {RouteExt.exact}
-   */
-  exactOnly?: boolean,
 
   /**
    * Schema to validate and transform path parameters. Uses Standard Schema
@@ -189,6 +183,13 @@ export interface RouteOptions<
    *   }
    */
   render?: (options: { outlet: RouteAtom['outlet'] }) => RouteChild
+
+  /**
+   * Render only on exact path matches
+   * 
+   * @see RouteExt.exact
+   */
+  exactRender?: boolean,
 }
 
 export interface RouteMixin<
@@ -545,7 +546,7 @@ const createRouteFactory = (parent: RouteAtom | UrlAtom) => {
       search: searchSchema,
       loader: optionsLoader = identity,
       render: renderFn,
-      exactOnly = false
+      exactRender = false
     } = options
 
     if (subPath.startsWith('/')) {
@@ -747,7 +748,7 @@ const createRouteFactory = (parent: RouteAtom | UrlAtom) => {
       }, `${name}._outlet`)
 
       const render = computed(() => {
-        return renderFn && (exactOnly ? exact() : match()) ? renderFn({ outlet }) : null
+        return renderFn && (exactRender ? exact() : match()) ? renderFn({ outlet }) : null
       }, `${name}._render`)
 
       return {


### PR DESCRIPTION
Implement `exactRender` flag that checks for exact match before doing `render()`