### PR TITLE
test(retry): add test for dependent computed recalculation

### DIFF
--- a/packages/core/src/methods/retry.test.ts
+++ b/packages/core/src/methods/retry.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'test'
 
 import { withAsync } from '../async'
-import { action } from '../core'
+import { action, computed } from '../core'
 import { retryComputed } from './retry'
+import { wrap } from './wrap'
 
 test('action retry disabled by default', async () => {
   const name = 'actionRetryDisabled'
@@ -11,4 +12,40 @@ test('action retry disabled by default', async () => {
   )
 
   expect(() => retryComputed(fetch)).toThrow('Only reactive atoms can be reset')
+})
+
+test('retryComputed should recalculate dependent computeds', async () => {
+  const computedA = computed(() => Math.random(), 'computedA')
+  const computedB = computed(() => computedA() * 10, 'computedB')
+
+  // Subscribe to both to track them
+  const valuesA: number[] = []
+  const valuesB: number[] = []
+
+  computedA.subscribe((v) => valuesA.push(v))
+  computedB.subscribe((v) => valuesB.push(v))
+
+  // Wait for initial subscriptions to settle
+  await wrap(Promise.resolve())
+
+  const initialA = valuesA[0]!
+  const initialB = valuesB[0]!
+
+  expect(initialB).toBe(initialA * 10)
+  expect(valuesA.length).toBe(1)
+  expect(valuesB.length).toBe(1)
+
+  // Retry computedA - should recalculate both A and B
+  retryComputed(computedA)
+
+  // Wait for notifications to propagate
+  await wrap(Promise.resolve())
+
+  const newA = valuesA[1]!
+  const newB = valuesB[1]!
+
+  expect(valuesA.length).toBe(2)
+  expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
+  expect(newA).not.toBe(initialA) // Should be a new random value
+  expect(newB).toBe(newA * 10) // computedB should have recalculated
 })


### PR DESCRIPTION
https://stackblitz.com/edit/vitejs-vite-gyfb2vmy?file=src%2Findex.css

```tsx
const App = reatomFactoryComponent(() => {
  const counter = reatomNumber(0, 'counter');

  const computedA = computed(() => Math.random(), 'computedA');

  const computedB = computed(() => computedA() * 10, 'computedB');

  const retry = action(() => {
    retryComputed(computedA);
  }, 'retry');
  return () => {
    return (
      <div>
        <div>{counter()}</div>
        <div>{computedA()}</div>
        <div>{computedB()}</div>
        <button onClick={wrap(retry)}>retry</button>
        <button onClick={wrap(() => counter.increment())}> increment</button>
      </div>
    );
  };
}, 'App');
```

After retry action only recalculates computedA, but that doesn't cause recalculate computedB and component render. counter atom increment action makes component rerender showing new value of
computedA and stale initial value of computedB. Further retry actions still not trigger render

<img width="1659" height="918" alt="image" src="https://github.com/user-attachments/assets/39cd5668-1d26-4de6-8000-d856c5255044" />
