### PR TITLE
Computed retry dependency fix

### DIFF
--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -897,7 +897,6 @@ export let createAtom: {
           }
 
           if (
-            !dirty &&
             subscribed &&
             (!Object.is(state, frame.state) || !Object.is(error, frame.error))
           ) {

--- a/packages/core/src/methods/retry.test.ts
+++ b/packages/core/src/methods/retry.test.ts
@@ -18,14 +18,12 @@ test('retryComputed should recalculate dependent computeds', async () => {
   const computedA = computed(() => Math.random(), 'computedA')
   const computedB = computed(() => computedA() * 10, 'computedB')
 
-  // Subscribe to both to track them
   const valuesA: number[] = []
   const valuesB: number[] = []
 
   computedA.subscribe((v) => valuesA.push(v))
   computedB.subscribe((v) => valuesB.push(v))
 
-  // Wait for initial subscriptions to settle
   await wrap(Promise.resolve())
 
   const initialA = valuesA[0]!
@@ -35,17 +33,15 @@ test('retryComputed should recalculate dependent computeds', async () => {
   expect(valuesA.length).toBe(1)
   expect(valuesB.length).toBe(1)
 
-  // Retry computedA - should recalculate both A and B
   retryComputed(computedA)
 
-  // Wait for notifications to propagate
   await wrap(Promise.resolve())
 
   const newA = valuesA[1]!
   const newB = valuesB[1]!
 
   expect(valuesA.length).toBe(2)
-  expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
-  expect(newA).not.toBe(initialA) // Should be a new random value
-  expect(newB).toBe(newA * 10) // computedB should have recalculated
+  expect(valuesB.length).toBe(2)
+  expect(newA).not.toBe(initialA)
+  expect(newB).toBe(newA * 10)
 })

--- a/packages/core/src/methods/retry.test.ts
+++ b/packages/core/src/methods/retry.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'test'
 
 import { withAsync } from '../async'
-import { action } from '../core'
+import { action, computed } from '../core'
 import { retryComputed } from './retry'
+import { wrap } from './wrap'
 
 test('action retry disabled by default', async () => {
   const name = 'actionRetryDisabled'
@@ -11,4 +12,40 @@ test('action retry disabled by default', async () => {
   )
 
   expect(() => retryComputed(fetch)).toThrow('Only reactive atoms can be reset')
+})
+
+test('retryComputed should recalculate dependent computeds', async () => {
+  const computedA = computed(() => Math.random(), 'computedA')
+  const computedB = computed(() => computedA() * 10, 'computedB')
+
+  // Subscribe to both to track them
+  const valuesA: number[] = []
+  const valuesB: number[] = []
+
+  computedA.subscribe((v) => valuesA.push(v))
+  computedB.subscribe((v) => valuesB.push(v))
+
+  // Wait for initial subscriptions to settle
+  await wrap(Promise.resolve())
+
+  const initialA = valuesA[0]!
+  const initialB = valuesB[0]!
+
+  expect(initialB).toBe(initialA * 10)
+  expect(valuesA.length).toBe(1)
+  expect(valuesB.length).toBe(1)
+
+  // Retry computedA - should recalculate both A and B
+  retryComputed(computedA)
+
+  // Wait for notifications to propagate
+  await wrap(Promise.resolve())
+
+  const newA = valuesA[1]!
+  const newB = valuesB[1]!
+
+  expect(valuesA.length).toBe(2)
+  expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
+  expect(newA).not.toBe(initialA) // Should be a new random value
+  expect(newB).toBe(newA * 10) // computedB should have recalculated
 })


### PR DESCRIPTION
Fix was prepared by Claude Code @ Opus 4.5

> Bug Fix: retryComputed not notifying dependents
> 
>   Root cause: In packages/core/src/core/atom.ts:899-905, the condition !dirty && prevented mark(frame) from being called when an atom was explicitly reset via retryComputed. The dirty flag was true after reset() sets pubs[0] = null, blocking subscriber notification.
> 
>   Fix: Removed the !dirty check. The mark function already guards against double-marking with subFrame.pubs[0] !== null.
> 
>   Files changed:
>   - packages/core/src/core/atom.ts - removed !dirty && from notification condition
>   - packages/core/src/methods/retry.test.ts - added test for dependent computed recalculation
> 
>   Test results: 275 passed (1 pre-existing failure in reatomField.test.ts unrelated to this fix)