### PR TITLE
Reatom documentation summary

### DIFF
--- a/docs/src/content/docs/handbook/forms/comparison.md
+++ b/docs/src/content/docs/handbook/forms/comparison.md
@@ -4,6 +4,7 @@ description: Comparison with other form libraries
 ---
 
 Legend:
+
 - 🟢 - fully supported
 - 🟡 - partial support
 - 🔴 - not supported
@@ -161,8 +162,8 @@ The core API selection is approximate and may not be fully accurate.
     </tbody>
 </table>
 
-1. *Decoupled form models* - the form logic (state, validation, and field dependencies) is fully defined as a standalone entity outside of the UI framework's lifecycle. It indicates whether the entire form model can be tested, reused, or ported to another framework without modifying the business logic, leaving the UI layer responsible only for data binding.
-2. *Reactivity granularity* there is limited to static dependency lists, while ideal behavior would involve automatic tracking like in signal-based architectures
+1. _Decoupled form models_ - the form logic (state, validation, and field dependencies) is fully defined as a standalone entity outside of the UI framework's lifecycle. It indicates whether the entire form model can be tested, reused, or ported to another framework without modifying the business logic, leaving the UI layer responsible only for data binding.
+2. _Reactivity granularity_ there is limited to static dependency lists, while ideal behavior would involve automatic tracking like in signal-based architectures
 3. Only debugger is available at this moment
 4. No built-in debounce and validation concurrency solution
 5. Validators are currently limited to subscribing to the state of other fields or form submission events. However, validation rule reactivity implies the ability to subscribe to any data source to dynamically update the rules.

--- a/docs/src/content/docs/handbook/forms/concepts/field-atom.md
+++ b/docs/src/content/docs/handbook/forms/concepts/field-atom.md
@@ -226,6 +226,7 @@ Using such schemas is quite straightforward, you just need to pass a standard-co
 :::caution[Zod implementation caution]
 You cannot throw errors in `.refine` <a href="https://zod.dev/api?id=refine" target="_blank">according to documentation</a> and the throwed error will not be propagated to the `reatomField` internals so we need a bunch of boilerplate to handle this.
 :::
+
 ```ts
 const usernameSchema = z
   .string()
@@ -237,25 +238,24 @@ const usernameSchema = z
         fetch(`/api/check-username?username=${value}`),
       )
       const data = await wrap(response.json())
-      if(!data) {
+      if (!data) {
         addIssue({
           code: 'custom',
           message: 'Username is already taken',
         })
       }
-    }
-    catch(error) {
-      if(!isAbort(error)) {
+    } catch (error) {
+      if (!isAbort(error)) {
         addIssue({
           code: 'custom',
           message: 'Error checking username',
         })
       }
     }
-  }),
+  })
 
 const usernameField = reatomField({
-  validate: usernameSchema
+  validate: usernameSchema,
 })
 ```
 
@@ -263,7 +263,7 @@ You can easily use standard schemas conditionally too:
 
 ```ts
 const usernameField = reatomField({
-  validate: async ({ focus }) => focus.touched ? usernameSchema : undefined,
+  validate: async ({ focus }) => (focus.touched ? usernameSchema : undefined),
 })
 ```
 

--- a/docs/src/content/docs/handbook/forms/recipes/auto-submit.md
+++ b/docs/src/content/docs/handbook/forms/recipes/auto-submit.md
@@ -30,16 +30,20 @@ effect(async () => {
 Here we must use `memo` to subscribe only to this specific part of the [`focus` atom](/handbook/forms/concepts/field-atom/#focus-atom) state, since it contains other states like `active`/`touched`, which could cause unexpected effect re-executions.
 
 ### `withFormAutoSubmit`
+
 Now let's take this bunch of logic and wrap it into a separate reusable extension:
+
 ```ts
 import { type Form, effect, memo, wrap, sleep } from 'reatom'
 
-export const withFormAutoSubmit = ({ 
-  debounceMs = 300
-}: { 
-  debounceMs?: number 
-} = {}) => (form: Form<any>) => {
-  effect(async () => {
+export const withFormAutoSubmit =
+  ({
+    debounceMs = 300,
+  }: {
+    debounceMs?: number
+  } = {}) =>
+  (form: Form<any>) => {
+    effect(async () => {
       const newValues = form()
 
       const dirty = memo(() => form.focus().dirty)
@@ -49,18 +53,20 @@ export const withFormAutoSubmit = ({
       await wrap(form.submit())
 
       form.init(newValues)
-  })
-  return form;
-}
+    })
+    return form
+  }
 ```
 
 Then just extend your form with `withFormAutoSubmit`:
+
 ```ts
-const form = reatomForm({
-  username: ''
-}, {
-  onSubmit: () => alert('Submitted')
-}).extend(
-  withFormAutoSubmit({ debounceMs: 500 })
-)
+const form = reatomForm(
+  {
+    username: '',
+  },
+  {
+    onSubmit: () => alert('Submitted'),
+  },
+).extend(withFormAutoSubmit({ debounceMs: 500 }))
 ```

--- a/docs/src/content/docs/handbook/forms/recipes/focus-management.md
+++ b/docs/src/content/docs/handbook/forms/recipes/focus-management.md
@@ -46,10 +46,11 @@ declare module '@reatom/core' {
 ```
 
 ### `withFormAutoFocusOnError`
+
 Now let's take this bunch of logic and wrap it into a separate reusable extension:
 
 ```ts
-export const withFormAutoFocusOnError = () => (form: Form<any>) => 
+export const withFormAutoFocusOnError = () => (form: Form<any>) =>
   form.submit.onReject.extend(
     withCallHook(() => {
       const errorField = form
@@ -61,17 +62,19 @@ export const withFormAutoFocusOnError = () => (form: Form<any>) =>
   )
 ```
 
-Then just extend your form with extension: 
+Then just extend your form with extension:
+
 ```ts
-const form = reatomForm({
-  login: '',
-  password: '',
-}, {
-  schema: z.object({
-    login: z.string().min(3),
-    password: z.string().min(6),
-  }),
-}).extend(
-  withFormAutoFocusOnError()
-)
+const form = reatomForm(
+  {
+    login: '',
+    password: '',
+  },
+  {
+    schema: z.object({
+      login: z.string().min(3),
+      password: z.string().min(6),
+    }),
+  },
+).extend(withFormAutoFocusOnError())
 ```

--- a/docs/src/content/docs/handbook/persist.md
+++ b/docs/src/content/docs/handbook/persist.md
@@ -46,10 +46,7 @@ Reatom provides ready-to-use adapters for all browser storage APIs with automati
 Perfect for persistent and session-based storage with cross-tab synchronization:
 
 ```typescript
-import {
-  withLocalStorage,
-  withSessionStorage,
-} from '@reatom/core/persist'
+import { withLocalStorage, withSessionStorage } from '@reatom/core/persist'
 
 // Persistent storage (survives browser restarts)
 const settingsAtom = atom({}, 'settings').extend(
@@ -261,10 +258,7 @@ Large-capacity persistent storage for complex applications:
 // First install the peer dependency:
 // npm install idb-keyval
 
-import {
-  withIndexedDb,
-  reatomPersistIndexedDb,
-} from '@reatom/core/persist'
+import { withIndexedDb, reatomPersistIndexedDb } from '@reatom/core/persist'
 
 // Default IndexedDB with automatic fallback
 const largeDataAtom = atom(new Map(), 'largeData').extend(

--- a/packages/core/src/async/withAsyncData.ts
+++ b/packages/core/src/async/withAsyncData.ts
@@ -27,8 +27,8 @@ export interface AsyncDataExt<
 >
   extends AsyncExt<Params, Payload, Error>, AbortExt {
   /**
-   * Atom that stores the fetched data Updated automatically when the
-   * async operation completes successfully
+   * Atom that stores the fetched data Updated automatically when the async
+   * operation completes successfully
    */
   data: Atom<InitState | State> & {
     reset: Action<[], InitState>
@@ -38,20 +38,19 @@ export interface AsyncDataExt<
   status: AsyncStatusAtom<State, InitState>
 
   /**
-   * Action that resets the async data atom by clearing its dependencies
-   * and resetting the data atom to its initial state. This is useful for
+   * Action that resets the async data atom by clearing its dependencies and
+   * resetting the data atom to its initial state. This is useful for
    * invalidating cached data and forcing a re-fetch on next access.
    *
-   * Note: This action does not re-trigger the async operation
-   * automatically. Use `retry` if you want to reset and immediately
-   * re-fetch.
+   * Note: This action does not re-trigger the async operation automatically.
+   * Use `retry` if you want to reset and immediately re-fetch.
    */
   reset: Action<[], void>
 
   /**
    * Action that retries the async operation by resetting dependencies and
-   * re-evaluating the computed function. This is useful for manually
-   * refreshing data or recovering from errors.
+   * re-evaluating the computed function. This is useful for manually refreshing
+   * data or recovering from errors.
    *
    * @returns The promise from the re-triggered async operation
    */

--- a/packages/core/src/core/action.test.ts
+++ b/packages/core/src/core/action.test.ts
@@ -85,5 +85,10 @@ test('subscribe', () => {
   expect(sub).toBeCalledWith([{ params: [1], payload: 1 }])
 })
 
-
-action(() => 123).extend(withMiddleware((target) => (next, ...params) => next(...params)))
+action(() => 123).extend(
+  withMiddleware(
+    (target) =>
+      (next, ...params) =>
+        next(...params),
+  ),
+)

--- a/packages/core/src/extensions/withSuspenseRetry.test.ts
+++ b/packages/core/src/extensions/withSuspenseRetry.test.ts
@@ -13,8 +13,8 @@ test('suspense retry', async () => {
   }).extend(withSuspenseInit())
 
   const act = action(async () => {
-    const result = suspenseAtom();
-    return result;
+    const result = suspenseAtom()
+    return result
   }).extend(withSuspenseRetry())
 
   expect(act()).resolves.toBe(1)

--- a/packages/core/src/methods/memo.ts
+++ b/packages/core/src/methods/memo.ts
@@ -10,9 +10,9 @@ import { computed, context, type Frame, named, ReatomError, top } from '../core'
  * The cache is scoped per-atom and persists across all calls to that atom
  * within the same context, making it suitable for creating internal computed
  * atoms or other resources that should be created once and reused.
- * 
+ *
  * @example
- *  // TODO cache 
+ *   // TODO cache
  *
  * @template T The type of value being cached
  * @param key Unique identifier for the cached value within the atom

--- a/packages/core/src/methods/retry.test.ts
+++ b/packages/core/src/methods/retry.test.ts
@@ -14,41 +14,38 @@ test('action retry disabled by default', async () => {
   expect(() => retryComputed(fetch)).toThrow('Only reactive atoms can be reset')
 })
 
-test(
-  'retryComputed should recalculate dependent computeds',
-  async () => {
-    const computedA = computed(() => Math.random(), 'computedA')
-    const computedB = computed(() => computedA() * 10, 'computedB')
+test('retryComputed should recalculate dependent computeds', async () => {
+  const computedA = computed(() => Math.random(), 'computedA')
+  const computedB = computed(() => computedA() * 10, 'computedB')
 
-    // Subscribe to both to track them
-    const valuesA: number[] = []
-    const valuesB: number[] = []
+  // Subscribe to both to track them
+  const valuesA: number[] = []
+  const valuesB: number[] = []
 
-    computedA.subscribe((v) => valuesA.push(v))
-    computedB.subscribe((v) => valuesB.push(v))
+  computedA.subscribe((v) => valuesA.push(v))
+  computedB.subscribe((v) => valuesB.push(v))
 
-    // Wait for initial subscriptions to settle
-    await wrap(Promise.resolve())
+  // Wait for initial subscriptions to settle
+  await wrap(Promise.resolve())
 
-    const initialA = valuesA[0]!
-    const initialB = valuesB[0]!
+  const initialA = valuesA[0]!
+  const initialB = valuesB[0]!
 
-    expect(initialB).toBe(initialA * 10)
-    expect(valuesA.length).toBe(1)
-    expect(valuesB.length).toBe(1)
+  expect(initialB).toBe(initialA * 10)
+  expect(valuesA.length).toBe(1)
+  expect(valuesB.length).toBe(1)
 
-    // Retry computedA - should recalculate both A and B
-    retryComputed(computedA)
+  // Retry computedA - should recalculate both A and B
+  retryComputed(computedA)
 
-    // Wait for notifications to propagate
-    await wrap(Promise.resolve())
+  // Wait for notifications to propagate
+  await wrap(Promise.resolve())
 
-    const newA = valuesA[1]!
-    const newB = valuesB[1]!
+  const newA = valuesA[1]!
+  const newB = valuesB[1]!
 
-    expect(valuesA.length).toBe(2)
-    expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
-    expect(newA).not.toBe(initialA) // Should be a new random value
-    expect(newB).toBe(newA * 10) // computedB should have recalculated
-  },
-)
+  expect(valuesA.length).toBe(2)
+  expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
+  expect(newA).not.toBe(initialA) // Should be a new random value
+  expect(newB).toBe(newA * 10) // computedB should have recalculated
+})

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -34,9 +34,9 @@ export type MaybeUnsubscribe =
   | void
   | Exclude<{}, Fn>
   | Unsubscribe
-  | ({
+  | {
       unsubscribe: Unsubscribe
-    })
+    }
 
 /**
  * Utility type that converts properties with undefined values to optional
@@ -837,7 +837,8 @@ export const withResolvers = <T>(): {
  * Removes the first occurrence of an item from an array in a single iteration.
  * Mutates the array in place by splicing out the found element.
  *
- * More efficient than using `indexOf` + `splice` as it only walks the array once.
+ * More efficient than using `indexOf` + `splice` as it only walks the array
+ * once.
  *
  * @example
  *   const items = [1, 2, 3, 4]

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,605 @@
+# Reatom SPA fast start summary
+
+## Goal and fit
+- From small widgets to complex SPAs, one universal model.
+- Portable state and logic across frameworks and runtimes.
+- Simple testing and mocking with explicit context tools.
+- Isomorphic and SSR-friendly with predictable async control.
+- Composable primitives, minimal API surface, high leverage extensions.
+
+## Core primitives and mental model
+Reatom is built around three base units and one extension system.
+
+- atom: mutable state container
+- computed: lazy derived state with dependency tracking
+- action: callable event, also observable
+- effect: computed that auto-subscribes for side effects
+- extend: attach capabilities, methods, or middleware
+
+### Minimal core example
+
+```ts
+import { atom, computed, action, effect } from '@reatom/core'
+
+const count = atom(0, 'count')
+
+const increment = action((step: number) => {
+  count.set((value) => value + step)
+  return count()
+}, 'count.increment')
+
+const isEven = computed(() => count() % 2 === 0, 'count.isEven')
+
+effect(() => {
+  const current = count()
+  const even = isEven()
+  console.log({ current, even })
+}, 'count.log')
+```
+
+Good practice
+- Always name atoms, actions, and computeds for tracing and logging.
+- Use action for complex flows and side effects, atom.set for local updates.
+- Prefer computed for derived values, effect for side effects.
+
+Tricky parts
+- Computed is lazy: it recalculates only when it is connected.
+- Effects track dependencies and auto-clean on abort or unmount.
+
+## Async model: withAsync, withAsyncData, wrap
+Two async extensions cover most cases:
+
+- withAsync: async actions for mutations and side effects
+- withAsyncData: async actions or computed for queries and cached data
+
+Both track pending and errors and integrate with async context and cancellation.
+
+### wrap rules
+wrap preserves async context for actions, effects, and atom updates.
+
+Rules of thumb
+- Wrap every async boundary that touches atoms or actions.
+- Wrap promise results and callbacks after await or in then.
+- Do not chain after wrap. Wrap each step.
+
+Good
+- const response = await wrap(fetch(url))
+- const data = await wrap(response.json())
+- await wrap(onEvent(button, 'click'))
+
+Bad
+- await wrap(fetch(url)).then((res) => res.json())
+
+### Async mutation example with withAsync
+
+```ts
+import { action, withAsync, wrap } from '@reatom/core'
+
+type UpdateResult = { ok: boolean }
+type UpdatePayload = { id: string; title: string }
+
+const updateItem = action(async (payload: UpdatePayload) => {
+  const response = await wrap(
+    fetch(`/api/items/${payload.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+  )
+  const result: UpdateResult = await wrap(response.json())
+  return result
+}, 'items.update').extend(withAsync())
+```
+
+Key points
+- updateItem.ready(), updateItem.pending(), updateItem.error()
+- updateItem.onFulfill/onReject/onSettle for lifecycle hooks
+- withAsync does not add abort by default, add withAbort if needed
+
+### Async query example with withAsyncData
+
+```ts
+import { computed, withAsyncData, wrap } from '@reatom/core'
+
+type User = { id: string; name: string }
+
+const currentUser = computed(async () => {
+  const response = await wrap(fetch('/api/me'))
+  const payload: User = await wrap(response.json())
+  return payload
+}, 'currentUser').extend(withAsyncData({ initState: null }))
+```
+
+Key points
+- currentUser.data(), currentUser.ready(), currentUser.error()
+- currentUser.reset() clears cached data and dependencies
+- currentUser.retry() re-runs the async computation
+- withAsyncData auto-aborts stale requests
+
+## Lifecycle and extension hooks
+### withConnectHook
+Runs when an atom gets its first subscriber, and auto-cleans on disconnect.
+
+Use it to lazy-start background work when data is actually needed.
+
+```ts
+import { atom, action, withConnectHook, wrap } from '@reatom/core'
+
+type Task = { id: string; title: string }
+
+const tasks = atom<Task[]>([], 'tasks')
+
+const loadTasks = action(async () => {
+  const response = await wrap(fetch('/api/tasks'))
+  const payload: Task[] = await wrap(response.json())
+  tasks.set(payload)
+}, 'tasks.load')
+
+tasks.extend(withConnectHook(() => loadTasks()))
+```
+
+Tricky
+- withConnectHook fires only on the first subscriber.
+- Use withConnectHook on the source atom, not on a downstream computed.
+
+### withChangeHook
+Runs on every state change in the Hooks phase.
+
+Good for stable cross-module wiring, not for dynamic factories.
+
+```ts
+import { atom, withChangeHook } from '@reatom/core'
+
+type Theme = 'light' | 'dark'
+
+const theme = atom<Theme>('light', 'theme').extend(
+  withChangeHook((nextTheme) => {
+    document.documentElement.dataset.theme = nextTheme
+  }),
+)
+```
+
+Tricky
+- Use effect with ifChanged for dynamic contexts.
+
+### withInit and isInit
+Attach dynamic initial state after creation and detect init phase.
+
+```ts
+import { atom, isInit, withComputed, withInit } from '@reatom/core'
+
+const sessionSeed = atom(() => crypto.randomUUID(), 'sessionSeed')
+
+const clientId = atom('', 'clientId').extend(
+  withInit(() => sessionSeed()),
+)
+
+const search = atom('', 'search')
+const page = atom(1, 'page').extend(
+  withComputed((state) => {
+    search()
+    return isInit() ? state : 1
+  }),
+)
+```
+
+### withComputed
+Adds computed logic to an atom or action. Use tail false only when dependency
+count is stable.
+
+## Event sampling and orchestration
+Reatom treats actions as reactive events and supports procedural flows.
+
+### take
+Waits for the next atom change or action call. Use wrap in async flows.
+
+### onEvent
+Bridges external events with abort-aware subscriptions or a single await.
+
+### ifChanged and getCalls
+Use inside computed or effect to react only to actual changes or new calls.
+
+```ts
+import { action, atom, effect, getCalls, ifChanged, onEvent, take, wrap } from '@reatom/core'
+
+const checkoutRequested = action((orderId: string) => orderId, 'checkout.requested')
+const confirmButton = atom<HTMLButtonElement | null>(null, 'confirmButton')
+const lastOrderId = atom('', 'lastOrderId')
+
+const checkoutFlow = action(async () => {
+  const orderId = await wrap(take(checkoutRequested))
+  const response = await wrap(fetch(`/api/orders/${orderId}/pay`))
+  const payload: { receiptId: string } = await wrap(response.json())
+  const element = confirmButton()
+  if (element) {
+    await wrap(onEvent(element, 'click'))
+  }
+  lastOrderId.set(payload.receiptId)
+  return payload.receiptId
+}, 'checkout.flow')
+
+effect(() => {
+  ifChanged(lastOrderId, (nextId) => {
+    if (nextId) console.log({ lastOrderId: nextId })
+  })
+}, 'checkout.lastOrderId')
+
+effect(() => {
+  const calls = getCalls(checkoutRequested)
+  calls.forEach(({ params }) => {
+    const orderId = params[0]
+    console.log({ checkoutRequested: orderId })
+  })
+}, 'checkout.requested.calls')
+```
+
+Tricky
+- take and onEvent must be wrapped inside async actions or effects.
+- getCalls only returns calls in the current batch, it is not a history store.
+
+## Memoization: memo and memoKey
+memo creates internal computed state inside a computed or action, scoped to the
+host atom. memoKey stores arbitrary per-atom values by key.
+
+```ts
+import { computed, memo, memoKey } from '@reatom/core'
+
+type Order = { total: number }
+type ApiClient = { baseUrl: string }
+
+const orders = computed((): Order[] => [], 'orders')
+
+const stats = computed(() => {
+  const items = orders()
+  const total = memo(() => items.reduce((sum, item) => sum + item.total, 0))
+  return { total }
+}, 'orders.stats')
+
+const client = computed(() => {
+  return memoKey('client', (): ApiClient => ({ baseUrl: '/api' }))
+}, 'api.client')
+```
+
+Tricky
+- memo uses the first callback only. Use stable closures.
+- Use a custom key when the same callback body is used multiple times.
+
+## Forms: base usage and reactive validation
+Forms are built from fields, field sets, and a submit action.
+
+Key primitives
+- reatomField: single field with state, value, focus, validation, disabled
+- reatomFieldSet: grouped fields with aggregate focus and validation
+- reatomForm: field set plus submit, schema validation, and form options
+
+### Base form with schema and submit
+
+```ts
+import { reatomField, reatomForm, wrap } from '@reatom/core'
+import { z } from 'zod/v4'
+
+type AuthResult = { token: string }
+
+const registerForm = reatomForm(
+  {
+    email: '',
+    password: '',
+    confirmPassword: reatomField('', {
+      validate: ({ state }) =>
+        state.length > 0 && state === registerForm.fields.password()
+          ? undefined
+          : 'Passwords do not match',
+    }),
+  },
+  {
+    name: 'registerForm',
+    validateOnBlur: true,
+    schema: z.object({
+      email: z.string().email(),
+      password: z.string().min(8),
+      confirmPassword: z.string().min(1),
+    }),
+    onSubmit: async (values): Promise<AuthResult> => {
+      const response = await wrap(
+        fetch('/api/register', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(values),
+        }),
+      )
+      const payload: AuthResult = await wrap(response.json())
+      return payload
+    },
+  },
+)
+```
+
+Reactive validation note
+- The validate callback tracks atoms it reads after the first trigger.
+- This enables dependent validation without manual wiring.
+
+Submit notes
+- submit is async and expects errors to be thrown.
+- submit.error() holds the latest error.
+- form.reset() cancels submit and resets submitted state.
+
+### React binding
+
+```tsx
+import { reatomComponent, bindField } from '@reatom/react'
+import { registerForm } from './registerForm'
+
+export const RegisterForm = reatomComponent(() => {
+  const { fields, submit, validation } = registerForm
+  const ready = submit.ready()
+  const error = submit.error()
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        submit()
+      }}
+    >
+      <input type="email" {...bindField(fields.email)} />
+      <input type="password" {...bindField(fields.password)} />
+      <input type="password" {...bindField(fields.confirmPassword)} />
+      <button type="submit" disabled={!ready}>
+        Create account
+      </button>
+      {validation().errors.length > 0 && <div>Fix validation errors</div>}
+      {error && <div>{error.message}</div>}
+    </form>
+  )
+}, 'RegisterForm')
+```
+
+Tricky
+- Validation errors for schema are distributed by path.
+- Triggered state for field sets is true only when all fields were triggered.
+
+## Routing + logger example (short but full-featured)
+This example uses routes, loaders, and logger setup for a typical SPA.
+
+### setup.ts
+
+```ts
+import { connectLogger, log } from '@reatom/core'
+
+if (import.meta.env.MODE === 'development') {
+  connectLogger()
+}
+
+declare global {
+  var LOG: typeof log
+}
+
+globalThis.LOG = log
+```
+
+### routes.ts
+
+```ts
+import { isSomeLoaderPending, reatomRoute, wrap } from '@reatom/core'
+import { z } from 'zod/v4'
+
+type User = { id: string; name: string; role: string }
+type UserList = { items: User[]; total: number }
+
+export const appRoute = reatomRoute('')
+export const dashboardRoute = appRoute.reatomRoute('dashboard')
+
+export const usersRoute = dashboardRoute.reatomRoute({
+  path: 'users',
+  search: z.object({
+    q: z.string().optional(),
+    page: z.string().regex(/^\d+$/).transform(Number).default('1'),
+  }),
+  async loader({ q, page }) {
+    const query = encodeURIComponent(q ?? '')
+    const response = await wrap(fetch(`/api/users?q=${query}&page=${page}`))
+    const payload: UserList = await wrap(response.json())
+    return payload
+  },
+})
+
+export const userRoute = usersRoute.reatomRoute({
+  path: ':userId',
+  params: z.object({
+    userId: z.string().regex(/^\d+$/),
+  }),
+  async loader({ userId }) {
+    const response = await wrap(fetch(`/api/users/${userId}`))
+    const payload: User = await wrap(response.json())
+    return payload
+  },
+})
+
+export const isRouteLoading = isSomeLoaderPending
+```
+
+### App and pages
+
+```tsx
+import { wrap } from '@reatom/core'
+import { reatomComponent } from '@reatom/react'
+import { isRouteLoading, userRoute, usersRoute } from './routes'
+
+export const UsersPage = reatomComponent(() => {
+  if (!usersRoute.match()) return null
+
+  const ready = usersRoute.loader.ready()
+  const error = usersRoute.loader.error()
+  if (!ready) return <div>Loading users</div>
+  if (error) return <div>{error.message}</div>
+
+  const data = usersRoute.loader.data()
+  return (
+    <section>
+      <h1>Users</h1>
+      <ul>
+        {data.items.map((user) => (
+          <li key={user.id}>
+            <button onClick={wrap(() => userRoute.go({ userId: user.id }))}>
+              {user.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}, 'UsersPage')
+
+export const UserDetails = reatomComponent(() => {
+  const params = userRoute()
+  if (!params) return null
+
+  const ready = userRoute.loader.ready()
+  const error = userRoute.loader.error()
+  if (!ready) return <div>Loading user</div>
+  if (error) return <div>{error.message}</div>
+
+  const user = userRoute.loader.data()
+  LOG('user.details', user)
+  return (
+    <section>
+      <h2>{user.name}</h2>
+      <div>{user.role}</div>
+    </section>
+  )
+}, 'UserDetails')
+
+export const App = reatomComponent(() => {
+  const loading = isRouteLoading()
+  return (
+    <main>
+      {loading && <div>Loading</div>}
+      <UsersPage />
+      <UserDetails />
+    </main>
+  )
+}, 'App')
+```
+
+Notes
+- Import setup.ts before any model to enable logger hooks.
+- Route loaders are async computed with auto-cancel.
+- Use wrap for event handlers and async boundaries.
+
+## Suspense notes
+Use suspense for global initialization, not for dynamic page data.
+
+- withSuspense adds .suspended() that throws promise for Suspense.
+- withSuspenseInit turns async init atoms into sync after init.
+- withSuspenseRetry retries actions that touch suspended atoms.
+- Use preserve to keep previous data during refresh.
+- Avoid non-idempotent side effects inside withSuspenseRetry.
+
+## Transactions notes
+Transactions support optimistic updates with rollback.
+
+- withRollback on atoms tracks state changes.
+- withTransaction on actions triggers rollback on errors.
+- action.rollback() rolls back only the last call of that action.
+- action.stop() commits the last call and clears rollback queue.
+- Abort does not trigger rollback.
+
+Example
+
+```ts
+import { action, atom, withAsync, withRollback, withTransaction, wrap } from '@reatom/core'
+
+type Todo = { id: string; title: string }
+
+const todos = atom<Todo[]>([], 'todos').extend(withRollback())
+
+const saveTodo = action(async (todo: Todo) => {
+  todos.set((items) => [...items, todo])
+  const response = await wrap(
+    fetch('/api/todos', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(todo),
+    }),
+  )
+  const result: Todo = await wrap(response.json())
+  return result
+}, 'todos.save').extend(withAsync(), withTransaction())
+```
+
+## SSR and testing
+- context.start creates isolated contexts for SSR requests or tests.
+- clearStack forces explicit wrap usage, useful for strict isolation.
+- context.reset clears the default global context between tests.
+
+## v3 migration highlights
+- Implicit context is default in v1000, ctx is not used.
+- ctx.schedule(promise) -> wrap(promise)
+- ctx.spy(atom) -> atom()
+- ctx.get(atom) -> peek(atom)
+- atom(callback) -> computed(callback)
+- atom(ctx, value) -> atom.set(value)
+- ctx.spy(atom, cb) -> ifChanged(atom, cb)
+- ctx.spy(action, cb) -> getCalls(action).forEach(cb)
+- reatomAsync(cb) -> action(cb).extend(withAsync())
+- reatomResource(cb) -> computed(cb).extend(withAsyncData())
+- reaction -> effect
+- atom.onChange(cb) -> atom.extend(withChangeHook(cb))
+- onConnect(atom, cb) -> atom.extend(withConnectHook(cb))
+- withConcurrency -> withAbort
+
+## Other APIs (not detailed here)
+Core
+- addGlobalExtension for global cross-cutting behavior
+- withActions for attaching methods as actions
+- withMiddleware and withParams for middleware and parameter transforms
+- bind for lightweight context binding
+- context, clearStack, mock, anonymizeNames for isolation and testing
+- isAtom, isAction, isComputed, isConnected, named for introspection
+
+Extensions
+- withAbort for abortable actions and computeds
+- withMemo to stabilize computed outputs
+- withDynamicSubscription to avoid unnecessary connections
+- withSuspense and withSuspenseRetry for Suspense integration
+- addChangeHook and addCallHook for dynamic hook wiring
+- withDisconnectHook for explicit disconnect actions
+
+Methods
+- abortVar and variable for async context variables
+- peek for non-reactive reads
+- schedule and retry for controlled reevaluation
+- deatomize to unwrap atoms into plain objects
+- reatomLens and reatomObservable for interop patterns
+- framePromise and getStackTrace for advanced debugging
+- isCausedBy to guard against self-triggered updates
+
+Routing helpers
+- searchParamsAtom and withSearchParams for URL search state
+- urlAtom for low-level URL control, link interception, sync hooks
+- is404 and isSomeLoaderPending for route status
+
+Primitives
+- reatomArray, reatomBoolean, reatomEnum, reatomNumber, reatomString
+- reatomMap, reatomSet, reatomRecord, reatomLinkedList
+
+Persistence
+- reatomPersist for custom storage adapters
+- withLocalStorage and withSessionStorage for web storage
+- withIndexedDb for IndexedDB persistence
+- withBroadcastChannel for cross-tab sync
+- withCookie and withCookieStore for cookie-backed state
+- createMemStorage for in-memory persistence in tests
+
+Web utilities
+- onLineAtom for network status
+- reatomMediaQuery for media query binding
+- reatomWebSocket for websocket state
+- rAF for requestAnimationFrame scheduling
+- fetch wrapper for consistent context usage
+
+Render adapter
+- reatomAbstractRender for building framework adapters
+
+Utils
+- General helpers for equality, abort errors, timers, and typed helpers

--- a/summary.md
+++ b/summary.md
@@ -80,6 +80,7 @@ priority.setHigh()
 ```
 
 Notes
+
 - **reatomBoolean** adds **setTrue**, **setFalse**, and **toggle** to keep updates semantic.
 - **reatomEnum** is perfect for literal list union inference in TypeScript.
 

--- a/summary.md
+++ b/summary.md
@@ -8,6 +8,10 @@
 - Isomorphic and SSR-friendly with predictable async control.
 - Composable primitives, minimal API surface, high leverage extensions.
 
+This summary is compact. The full handbook and reference cover deeper API
+details, recipes, and adapters in /docs/start, /docs/handbook, and
+/docs/reference.
+
 ## Core primitives and mental model
 
 Reatom is built around three base units and one extension system.
@@ -39,10 +43,31 @@ effect(() => {
 }, 'count.log')
 ```
 
+### extend example
+
+```ts
+import { action, atom, computed, wrap } from '@reatom/core'
+
+type Item = { id: string; title: string }
+
+const items = atom<Item[]>([], 'items').extend((target) => {
+  const count = computed(() => target().length, `${target.name}.count`)
+  const load = action(async (listId: string) => {
+    const response = await wrap(fetch(`/api/lists/${listId}`))
+    const payload: Item[] = await wrap(response.json())
+    target.set(payload)
+    return payload
+  }, `${target.name}.load`)
+  return { count, load }
+})
+```
+
 Good practice
 
 - Always name atoms, actions, and computeds for tracing and logging.
 - Use action for complex flows and side effects, atom.set for local updates.
+- Avoid one-line actions that only forward data to atoms. Direct atom.set is
+  preferred and still keeps a clear cause via async context.
 - Prefer computed for derived values, effect for side effects.
 
 Tricky parts
@@ -135,21 +160,10 @@ Runs when an atom gets its first subscriber, and auto-cleans on disconnect.
 
 Use it to lazy-start background work when data is actually needed.
 
-```ts
-import { atom, action, withConnectHook, wrap } from '@reatom/core'
-
-type Task = { id: string; title: string }
-
-const tasks = atom<Task[]>([], 'tasks')
-
-const loadTasks = action(async () => {
-  const response = await wrap(fetch('/api/tasks'))
-  const payload: Task[] = await wrap(response.json())
-  tasks.set(payload)
-}, 'tasks.load')
-
-tasks.extend(withConnectHook(() => loadTasks()))
-```
+Useful cases
+- Start polling only while a screen is mounted or data is subscribed.
+- Attach and detach external listeners, websockets, or subscriptions.
+- Initialize expensive models when a route or component connects.
 
 Tricky
 
@@ -162,17 +176,10 @@ Runs on every state change in the Hooks phase.
 
 Good for stable cross-module wiring, not for dynamic factories.
 
-```ts
-import { atom, withChangeHook } from '@reatom/core'
-
-type Theme = 'light' | 'dark'
-
-const theme = atom<Theme>('light', 'theme').extend(
-  withChangeHook((nextTheme) => {
-    document.documentElement.dataset.theme = nextTheme
-  }),
-)
-```
+Useful cases
+- Persist settings to storage or sync into non-reactive APIs.
+- Send analytics when global atoms change.
+- Keep document title or UI theme in sync with global state.
 
 Tricky
 
@@ -231,16 +238,17 @@ import {
   wrap,
 } from '@reatom/core'
 
-const checkoutRequested = action(
-  (orderId: string) => orderId,
-  'checkout.requested',
-)
+type CheckoutRequest = { orderId: string; requestedAt: number }
+
+const checkoutRequested = action((orderId: string): CheckoutRequest => {
+  return { orderId, requestedAt: Date.now() }
+}, 'checkout.requested')
 const confirmButton = atom<HTMLButtonElement | null>(null, 'confirmButton')
 const lastOrderId = atom('', 'lastOrderId')
 
 const checkoutFlow = action(async () => {
-  const orderId = await wrap(take(checkoutRequested))
-  const response = await wrap(fetch(`/api/orders/${orderId}/pay`))
+  const request = await wrap(take(checkoutRequested))
+  const response = await wrap(fetch(`/api/orders/${request.orderId}/pay`))
   const payload: { receiptId: string } = await wrap(response.json())
   const element = confirmButton()
   if (element) {
@@ -258,8 +266,8 @@ effect(() => {
 
 effect(() => {
   const calls = getCalls(checkoutRequested)
-  calls.forEach(({ params }) => {
-    const orderId = params[0]
+  calls.forEach(({ payload }) => {
+    const orderId = payload.orderId
     console.log({ checkoutRequested: orderId })
   })
 }, 'checkout.requested.calls')
@@ -528,6 +536,41 @@ Notes
 - Route loaders are async computed with auto-cancel.
 - Use wrap for event handlers and async boundaries.
 
+## URL sync and persistence helpers
+
+### withSearchParams for list filters
+
+```ts
+import { atom, withSearchParams } from '@reatom/core'
+
+type Sort = 'popular' | 'new' | 'price'
+
+const query = atom('', 'catalog.query').extend(withSearchParams('q'))
+const page = atom(1, 'catalog.page').extend(
+  withSearchParams('page', {
+    parse: (value) => Number(value ?? '1'),
+    serialize: (value) => (value === 1 ? undefined : String(value)),
+  }),
+)
+const sort = atom<Sort>('popular', 'catalog.sort').extend(
+  withSearchParams('sort', (value) =>
+    value === 'new' || value === 'price' || value === 'popular'
+      ? value
+      : 'popular',
+  ),
+)
+```
+
+### withLocalStorage for preferences
+
+```ts
+import { atom, withLocalStorage } from '@reatom/core'
+
+type Theme = 'light' | 'dark'
+
+const theme = atom<Theme>('light', 'theme').extend(withLocalStorage('theme'))
+```
+
 ## Suspense notes
 
 Use suspense for global initialization, not for dynamic page data.
@@ -602,7 +645,8 @@ const saveTodo = action(async (todo: Todo) => {
 - withConcurrency -> withAbort
 
 ## Other APIs (not detailed here)
-
+This list is intentionally brief. See the full handbook and reference for
+additional features, recipes, adapters, and edge cases.
 Core
 
 - addGlobalExtension for global cross-cutting behavior

--- a/summary.md
+++ b/summary.md
@@ -16,11 +16,11 @@ details, recipes, and adapters in /docs/start, /docs/handbook, and
 
 Reatom is built around three base units and one extension system.
 
-- atom: mutable state container
-- computed: lazy derived state with dependency tracking
-- action: callable event, also observable
-- effect: computed that auto-subscribes for side effects
-- extend: attach capabilities, methods, or middleware
+- **atom**: mutable state container
+- **computed**: lazy derived state with dependency tracking
+- **action**: callable event, also observable
+- **effect**: computed that auto-subscribes for side effects
+- **extend**: attach capabilities, methods, or middleware
 
 ### Minimal core example
 
@@ -62,37 +62,58 @@ const items = atom<Item[]>([], 'items').extend((target) => {
 })
 ```
 
+### Primitives quick usage
+
+```ts
+import { reatomBoolean, reatomEnum } from '@reatom/core'
+
+type Priority = 'low' | 'medium' | 'high'
+
+const isModalOpen = reatomBoolean(false, 'isModalOpen')
+isModalOpen.setTrue()
+isModalOpen.setFalse()
+isModalOpen.toggle()
+
+const priority = reatomEnum(['low', 'medium', 'high'], 'priority')
+const currentPriority: Priority = priority()
+priority.setHigh()
+```
+
+Notes
+- **reatomBoolean** adds **setTrue**, **setFalse**, and **toggle** to keep updates semantic.
+- **reatomEnum** is perfect for literal list union inference in TypeScript.
+
 Good practice
 
-- Always name atoms, actions, and computeds for tracing and logging.
-- Use action for complex flows and side effects, atom.set for local updates.
-- Avoid one-line actions that only forward data to atoms. Direct atom.set is
+- Always name **atoms**, **actions**, and **computed** values for tracing and logging.
+- Use **action** for complex flows and side effects, **atom.set** for local updates.
+- Avoid one-line actions that only forward data to atoms. Direct **atom.set** is
   preferred and still keeps a clear cause via async context.
-- Prefer computed for derived values, effect for side effects.
+- Prefer **computed** for derived values, **effect** for side effects.
 
 Tricky parts
 
-- Computed is lazy: it recalculates only when it is connected.
-- Effects track dependencies and auto-clean on abort or unmount.
+- **computed** is lazy: it recalculates only when it is connected.
+- **effect** tracks dependencies and auto-clean on abort or unmount.
 
-## Async model: withAsync, withAsyncData, wrap
+## Async model: **withAsync**, **withAsyncData**, **wrap**
 
 Two async extensions cover most cases:
 
-- withAsync: async actions for mutations and side effects
-- withAsyncData: async actions or computed for queries and cached data
+- **withAsync**: async actions for mutations and side effects
+- **withAsyncData**: async actions or computed for queries and cached data
 
 Both track pending and errors and integrate with async context and cancellation.
 
-### wrap rules
+### **wrap** rules
 
-wrap preserves async context for actions, effects, and atom updates.
+**wrap** preserves async context for actions, effects, and atom updates.
 
 Rules of thumb
 
-- Wrap every async boundary that touches atoms or actions.
-- Wrap promise results and callbacks after await or in then.
-- Do not chain after wrap. Wrap each step.
+- Use **wrap** on every async boundary that touches atoms or actions.
+- Use **wrap** for promise results and callbacks after await or in then.
+- Do not chain after **wrap**. Wrap each step.
 
 Good
 
@@ -104,7 +125,7 @@ Bad
 
 - await wrap(fetch(url)).then((res) => res.json())
 
-### Async mutation example with withAsync
+### Async mutation example with **withAsync**
 
 ```ts
 import { action, withAsync, wrap } from '@reatom/core'
@@ -127,11 +148,11 @@ const updateItem = action(async (payload: UpdatePayload) => {
 
 Key points
 
-- updateItem.ready(), updateItem.pending(), updateItem.error()
-- updateItem.onFulfill/onReject/onSettle for lifecycle hooks
-- withAsync does not add abort by default, add withAbort if needed
+- **updateItem.ready()**, **updateItem.pending()**, **updateItem.error()**
+- **updateItem.onFulfill**, **updateItem.onReject**, **updateItem.onSettle** for lifecycle hooks
+- **withAsync** does not add abort by default, add **withAbort** if needed
 
-### Async query example with withAsyncData
+### Async query example with **withAsyncData**
 
 ```ts
 import { computed, withAsyncData, wrap } from '@reatom/core'
@@ -147,18 +168,18 @@ const currentUser = computed(async () => {
 
 Key points
 
-- currentUser.data(), currentUser.ready(), currentUser.error()
-- currentUser.reset() clears cached data and dependencies
-- currentUser.retry() re-runs the async computation
-- withAsyncData auto-aborts stale requests
+- **currentUser.data()**, **currentUser.ready()**, **currentUser.error()**
+- **currentUser.reset()** clears cached data and dependencies
+- **currentUser.retry()** re-runs the async computation
+- **withAsyncData** auto-aborts stale requests
 
 ## Lifecycle and extension hooks
 
-### withConnectHook
+### **withConnectHook**
 
 Runs when an atom gets its first subscriber, and auto-cleans on disconnect.
 
-Use it to lazy-start background work when data is actually needed.
+Use **withConnectHook** to lazy-start background work when data is actually needed.
 
 Useful cases
 
@@ -168,10 +189,10 @@ Useful cases
 
 Tricky
 
-- withConnectHook fires only on the first subscriber.
-- Use withConnectHook on the source atom, not on a downstream computed.
+- **withConnectHook** fires only on the first subscriber.
+- Use **withConnectHook** on the source atom, not on a downstream **computed**.
 
-### withChangeHook
+### **withChangeHook**
 
 Runs on every state change in the Hooks phase.
 
@@ -185,9 +206,9 @@ Useful cases
 
 Tricky
 
-- Use effect with ifChanged for dynamic contexts.
+- Use **effect** with **ifChanged** for dynamic contexts.
 
-### withInit and isInit
+### **withInit** and **isInit**
 
 Attach dynamic initial state after creation and detect init phase.
 
@@ -207,7 +228,7 @@ const page = atom(1, 'page').extend(
 )
 ```
 
-### withComputed
+### **withComputed**
 
 Adds computed logic to an atom or action. Use tail false only when dependency
 count is stable.
@@ -216,17 +237,18 @@ count is stable.
 
 Reatom treats actions as reactive events and supports procedural flows.
 
-### take
+### **take**
 
-Waits for the next atom change or action call. Use wrap in async flows.
+Waits for the next atom change or action call. Use **wrap** in async flows.
+Cool for forms: wait for **submit** or a validation change without extra wiring.
 
-### onEvent
+### **onEvent**
 
 Bridges external events with abort-aware subscriptions or a single await.
 
-### ifChanged and getCalls
+### **ifChanged** and **getCalls**
 
-Use inside computed or effect to react only to actual changes or new calls.
+Use inside **computed** or **effect** to react only to actual changes or new calls.
 
 ```ts
 import {
@@ -277,13 +299,14 @@ effect(() => {
 
 Tricky
 
-- take and onEvent must be wrapped inside async actions or effects.
-- getCalls only returns calls in the current batch, it is not a history store.
+- **take** and **onEvent** must be wrapped inside async actions or effects.
+- **getCalls** only returns calls in the current batch, it is not a history store.
+- Use **ifChanged** only inside **effect** or **computed** with a few dependencies.
 
-## Memoization: memo and memoKey
+## Memoization: **memo** and **memoKey**
 
-memo creates internal computed state inside a computed or action, scoped to the
-host atom. memoKey stores arbitrary per-atom values by key.
+**memo** creates internal computed state inside a **computed** or **action**, scoped to the
+host atom. **memoKey** stores arbitrary per-atom values by key.
 
 ```ts
 import { computed, memo, memoKey } from '@reatom/core'
@@ -306,18 +329,19 @@ const client = computed(() => {
 
 Tricky
 
-- memo uses the first callback only. Use stable closures.
+- Use **memo** only inside **effect** or **computed** with a few dependencies.
+- **memo** uses the first callback only. Use stable closures.
 - Use a custom key when the same callback body is used multiple times.
 
 ## Forms: base usage and reactive validation
 
-Forms are built from fields, field sets, and a submit action.
+Forms are built from fields, field sets, and a **submit** action.
 
 Key primitives
 
-- reatomField: single field with state, value, focus, validation, disabled
-- reatomFieldSet: grouped fields with aggregate focus and validation
-- reatomForm: field set plus submit, schema validation, and form options
+- **reatomField**: single field with state, value, focus, validation, disabled
+- **reatomFieldSet**: grouped fields with aggregate focus and validation
+- **reatomForm**: field set plus submit, schema validation, and form options
 
 ### Base form with schema and submit
 
@@ -368,9 +392,9 @@ Reactive validation note
 
 Submit notes
 
-- submit is async and expects errors to be thrown.
-- submit.error() holds the latest error.
-- form.reset() cancels submit and resets submitted state.
+- **submit** is async and expects errors to be thrown.
+- **submit.error()** holds the latest error.
+- **form.reset()** cancels submit and resets submitted state.
 
 ### React binding
 
@@ -534,13 +558,13 @@ export const App = reatomComponent(() => {
 
 Notes
 
-- Import setup.ts before any model to enable logger hooks.
+- Import setup.ts before any model to enable **connectLogger** hooks.
 - Route loaders are async computed with auto-cancel.
-- Use wrap for event handlers and async boundaries.
+- Use **wrap** for event handlers and async boundaries.
 
 ## URL sync and persistence helpers
 
-### withSearchParams for list filters
+### **withSearchParams** for list filters
 
 ```ts
 import { atom, withSearchParams } from '@reatom/core'
@@ -563,7 +587,7 @@ const sort = atom<Sort>('popular', 'catalog.sort').extend(
 )
 ```
 
-### withLocalStorage for preferences
+### **withLocalStorage** for preferences
 
 ```ts
 import { atom, withLocalStorage } from '@reatom/core'
@@ -577,20 +601,20 @@ const theme = atom<Theme>('light', 'theme').extend(withLocalStorage('theme'))
 
 Use suspense for global initialization, not for dynamic page data.
 
-- withSuspense adds .suspended() that throws promise for Suspense.
-- withSuspenseInit turns async init atoms into sync after init.
-- withSuspenseRetry retries actions that touch suspended atoms.
-- Use preserve to keep previous data during refresh.
-- Avoid non-idempotent side effects inside withSuspenseRetry.
+- **withSuspense** adds **.suspended()** that throws promise for Suspense.
+- **withSuspenseInit** turns async init atoms into sync after init.
+- **withSuspenseRetry** retries actions that touch suspended atoms.
+- Use **preserve** to keep previous data during refresh.
+- Avoid non-idempotent side effects inside **withSuspenseRetry**.
 
 ## Transactions notes
 
 Transactions support optimistic updates with rollback.
 
-- withRollback on atoms tracks state changes.
-- withTransaction on actions triggers rollback on errors.
-- action.rollback() rolls back only the last call of that action.
-- action.stop() commits the last call and clears rollback queue.
+- **withRollback** on atoms tracks state changes.
+- **withTransaction** on actions triggers rollback on errors.
+- **action.rollback()** rolls back only the last call of that action.
+- **action.stop()** commits the last call and clears rollback queue.
 - Abort does not trigger rollback.
 
 Example
@@ -625,26 +649,26 @@ const saveTodo = action(async (todo: Todo) => {
 
 ## SSR and testing
 
-- context.start creates isolated contexts for SSR requests or tests.
-- clearStack forces explicit wrap usage, useful for strict isolation.
-- context.reset clears the default global context between tests.
+- **context.start** creates isolated contexts for SSR requests or tests.
+- **clearStack** forces explicit **wrap** usage, useful for strict isolation.
+- **context.reset** clears the default global context between tests.
 
 ## v3 migration highlights
 
-- Implicit context is default in v1000, ctx is not used.
-- ctx.schedule(promise) -> wrap(promise)
-- ctx.spy(atom) -> atom()
-- ctx.get(atom) -> peek(atom)
-- atom(callback) -> computed(callback)
-- atom(ctx, value) -> atom.set(value)
-- ctx.spy(atom, cb) -> ifChanged(atom, cb)
-- ctx.spy(action, cb) -> getCalls(action).forEach(cb)
-- reatomAsync(cb) -> action(cb).extend(withAsync())
-- reatomResource(cb) -> computed(cb).extend(withAsyncData())
-- reaction -> effect
-- atom.onChange(cb) -> atom.extend(withChangeHook(cb))
-- onConnect(atom, cb) -> atom.extend(withConnectHook(cb))
-- withConcurrency -> withAbort
+- Implicit context is default in v1000, **ctx** is not used.
+- **ctx.schedule**(promise) -> **wrap**(promise)
+- **ctx.spy**(atom) -> **atom**()
+- **ctx.get**(atom) -> **peek**(atom)
+- **atom**(callback) -> **computed**(callback)
+- **atom**(ctx, value) -> **atom.set**(value)
+- **ctx.spy**(atom, cb) -> **ifChanged**(atom, cb)
+- **ctx.spy**(action, cb) -> **getCalls**(action).forEach(cb)
+- **reatomAsync**(cb) -> **action**(cb).extend(**withAsync**())
+- **reatomResource**(cb) -> **computed**(cb).extend(**withAsyncData**())
+- **reaction** -> **effect**
+- **atom.onChange**(cb) -> **atom.extend**(**withChangeHook**(cb))
+- **onConnect**(atom, cb) -> **atom.extend**(**withConnectHook**(cb))
+- **withConcurrency** -> **withAbort**
 
 ## Other APIs (not detailed here)
 
@@ -652,63 +676,63 @@ This list is intentionally brief. See the full handbook and reference for
 additional features, recipes, adapters, and edge cases.
 Core
 
-- addGlobalExtension for global cross-cutting behavior
-- withActions for attaching methods as actions
-- withMiddleware and withParams for middleware and parameter transforms
-- bind for lightweight context binding
-- context, clearStack, mock, anonymizeNames for isolation and testing
-- isAtom, isAction, isComputed, isConnected, named for introspection
+- **addGlobalExtension** for global cross-cutting behavior
+- **withActions** for attaching methods as actions
+- **withMiddleware** and **withParams** for middleware and parameter transforms
+- **bind** for lightweight context binding
+- **context**, **clearStack**, **mock**, **anonymizeNames** for isolation and testing
+- **isAtom**, **isAction**, **isComputed**, **isConnected**, **named** for introspection
 
 Extensions
 
-- withAbort for abortable actions and computeds
-- withMemo to stabilize computed outputs
-- withDynamicSubscription to avoid unnecessary connections
-- withSuspense and withSuspenseRetry for Suspense integration
-- addChangeHook and addCallHook for dynamic hook wiring
-- withDisconnectHook for explicit disconnect actions
+- **withAbort** for abortable actions and computeds
+- **withMemo** to stabilize computed outputs
+- **withDynamicSubscription** to avoid unnecessary connections
+- **withSuspense** and **withSuspenseRetry** for Suspense integration
+- **addChangeHook** and **addCallHook** for dynamic hook wiring
+- **withDisconnectHook** for explicit disconnect actions
 
 Methods
 
-- abortVar and variable for async context variables
-- peek for non-reactive reads
-- schedule and retry for controlled reevaluation
-- deatomize to unwrap atoms into plain objects
-- reatomLens and reatomObservable for interop patterns
-- framePromise and getStackTrace for advanced debugging
-- isCausedBy to guard against self-triggered updates
+- **abortVar** and **variable** for async context variables
+- **peek** for non-reactive reads
+- **schedule** and **retry** for controlled reevaluation
+- **deatomize** to unwrap atoms into plain objects
+- **reatomLens** and **reatomObservable** for interop patterns
+- **framePromise** and **getStackTrace** for advanced debugging
+- **isCausedBy** to guard against self-triggered updates
 
 Routing helpers
 
-- searchParamsAtom and withSearchParams for URL search state
-- urlAtom for low-level URL control, link interception, sync hooks
-- is404 and isSomeLoaderPending for route status
+- **searchParamsAtom** and **withSearchParams** for URL search state
+- **urlAtom** for low-level URL control, link interception, sync hooks
+- **is404** and **isSomeLoaderPending** for route status
 
 Primitives
 
-- reatomArray, reatomBoolean, reatomEnum, reatomNumber, reatomString
-- reatomMap, reatomSet, reatomRecord, reatomLinkedList
+- **reatomArray**, **reatomBoolean**, **reatomEnum**, **reatomNumber**, **reatomString**
+- **reatomMap**, **reatomSet**, **reatomRecord**, **reatomLinkedList**
 
 Persistence
 
-- reatomPersist for custom storage adapters
-- withLocalStorage and withSessionStorage for web storage
-- withIndexedDb for IndexedDB persistence
-- withBroadcastChannel for cross-tab sync
-- withCookie and withCookieStore for cookie-backed state
-- createMemStorage for in-memory persistence in tests
+- **reatomPersist** for custom storage adapters
+- **withLocalStorage** and **withSessionStorage** for web storage
+- **withIndexedDb** for IndexedDB persistence
+- **withBroadcastChannel** for cross-tab sync
+- **withCookie** and **withCookieStore** for cookie-backed state
+- **createMemStorage** for in-memory persistence in tests
 
 Web utilities
 
-- onLineAtom for network status
-- reatomMediaQuery for media query binding
-- reatomWebSocket for websocket state
-- rAF for requestAnimationFrame scheduling
-- fetch wrapper for consistent context usage
+- **onLineAtom** for network status
+- **reatomMediaQuery** for media query binding
+- **reatomWebSocket** for websocket state
+- **rAF** for requestAnimationFrame scheduling
+- **fetch** wrapper for consistent context usage
 
 Render adapter
 
-- reatomAbstractRender for building framework adapters
+- **reatomAbstractRender** for building framework adapters
 
 Utils
 

--- a/summary.md
+++ b/summary.md
@@ -161,6 +161,7 @@ Runs when an atom gets its first subscriber, and auto-cleans on disconnect.
 Use it to lazy-start background work when data is actually needed.
 
 Useful cases
+
 - Start polling only while a screen is mounted or data is subscribed.
 - Attach and detach external listeners, websockets, or subscriptions.
 - Initialize expensive models when a route or component connects.
@@ -177,6 +178,7 @@ Runs on every state change in the Hooks phase.
 Good for stable cross-module wiring, not for dynamic factories.
 
 Useful cases
+
 - Persist settings to storage or sync into non-reactive APIs.
 - Send analytics when global atoms change.
 - Keep document title or UI theme in sync with global state.
@@ -645,6 +647,7 @@ const saveTodo = action(async (todo: Todo) => {
 - withConcurrency -> withAbort
 
 ## Other APIs (not detailed here)
+
 This list is intentionally brief. See the full handbook and reference for
 additional features, recipes, adapters, and edge cases.
 Core

--- a/summary.md
+++ b/summary.md
@@ -1,6 +1,7 @@
 # Reatom SPA fast start summary
 
 ## Goal and fit
+
 - From small widgets to complex SPAs, one universal model.
 - Portable state and logic across frameworks and runtimes.
 - Simple testing and mocking with explicit context tools.
@@ -8,6 +9,7 @@
 - Composable primitives, minimal API surface, high leverage extensions.
 
 ## Core primitives and mental model
+
 Reatom is built around three base units and one extension system.
 
 - atom: mutable state container
@@ -38,15 +40,18 @@ effect(() => {
 ```
 
 Good practice
+
 - Always name atoms, actions, and computeds for tracing and logging.
 - Use action for complex flows and side effects, atom.set for local updates.
 - Prefer computed for derived values, effect for side effects.
 
 Tricky parts
+
 - Computed is lazy: it recalculates only when it is connected.
 - Effects track dependencies and auto-clean on abort or unmount.
 
 ## Async model: withAsync, withAsyncData, wrap
+
 Two async extensions cover most cases:
 
 - withAsync: async actions for mutations and side effects
@@ -55,19 +60,23 @@ Two async extensions cover most cases:
 Both track pending and errors and integrate with async context and cancellation.
 
 ### wrap rules
+
 wrap preserves async context for actions, effects, and atom updates.
 
 Rules of thumb
+
 - Wrap every async boundary that touches atoms or actions.
 - Wrap promise results and callbacks after await or in then.
 - Do not chain after wrap. Wrap each step.
 
 Good
+
 - const response = await wrap(fetch(url))
 - const data = await wrap(response.json())
 - await wrap(onEvent(button, 'click'))
 
 Bad
+
 - await wrap(fetch(url)).then((res) => res.json())
 
 ### Async mutation example with withAsync
@@ -92,6 +101,7 @@ const updateItem = action(async (payload: UpdatePayload) => {
 ```
 
 Key points
+
 - updateItem.ready(), updateItem.pending(), updateItem.error()
 - updateItem.onFulfill/onReject/onSettle for lifecycle hooks
 - withAsync does not add abort by default, add withAbort if needed
@@ -111,13 +121,16 @@ const currentUser = computed(async () => {
 ```
 
 Key points
+
 - currentUser.data(), currentUser.ready(), currentUser.error()
 - currentUser.reset() clears cached data and dependencies
 - currentUser.retry() re-runs the async computation
 - withAsyncData auto-aborts stale requests
 
 ## Lifecycle and extension hooks
+
 ### withConnectHook
+
 Runs when an atom gets its first subscriber, and auto-cleans on disconnect.
 
 Use it to lazy-start background work when data is actually needed.
@@ -139,10 +152,12 @@ tasks.extend(withConnectHook(() => loadTasks()))
 ```
 
 Tricky
+
 - withConnectHook fires only on the first subscriber.
 - Use withConnectHook on the source atom, not on a downstream computed.
 
 ### withChangeHook
+
 Runs on every state change in the Hooks phase.
 
 Good for stable cross-module wiring, not for dynamic factories.
@@ -160,9 +175,11 @@ const theme = atom<Theme>('light', 'theme').extend(
 ```
 
 Tricky
+
 - Use effect with ifChanged for dynamic contexts.
 
 ### withInit and isInit
+
 Attach dynamic initial state after creation and detect init phase.
 
 ```ts
@@ -170,9 +187,7 @@ import { atom, isInit, withComputed, withInit } from '@reatom/core'
 
 const sessionSeed = atom(() => crypto.randomUUID(), 'sessionSeed')
 
-const clientId = atom('', 'clientId').extend(
-  withInit(() => sessionSeed()),
-)
+const clientId = atom('', 'clientId').extend(withInit(() => sessionSeed()))
 
 const search = atom('', 'search')
 const page = atom(1, 'page').extend(
@@ -184,25 +199,42 @@ const page = atom(1, 'page').extend(
 ```
 
 ### withComputed
+
 Adds computed logic to an atom or action. Use tail false only when dependency
 count is stable.
 
 ## Event sampling and orchestration
+
 Reatom treats actions as reactive events and supports procedural flows.
 
 ### take
+
 Waits for the next atom change or action call. Use wrap in async flows.
 
 ### onEvent
+
 Bridges external events with abort-aware subscriptions or a single await.
 
 ### ifChanged and getCalls
+
 Use inside computed or effect to react only to actual changes or new calls.
 
 ```ts
-import { action, atom, effect, getCalls, ifChanged, onEvent, take, wrap } from '@reatom/core'
+import {
+  action,
+  atom,
+  effect,
+  getCalls,
+  ifChanged,
+  onEvent,
+  take,
+  wrap,
+} from '@reatom/core'
 
-const checkoutRequested = action((orderId: string) => orderId, 'checkout.requested')
+const checkoutRequested = action(
+  (orderId: string) => orderId,
+  'checkout.requested',
+)
 const confirmButton = atom<HTMLButtonElement | null>(null, 'confirmButton')
 const lastOrderId = atom('', 'lastOrderId')
 
@@ -234,10 +266,12 @@ effect(() => {
 ```
 
 Tricky
+
 - take and onEvent must be wrapped inside async actions or effects.
 - getCalls only returns calls in the current batch, it is not a history store.
 
 ## Memoization: memo and memoKey
+
 memo creates internal computed state inside a computed or action, scoped to the
 host atom. memoKey stores arbitrary per-atom values by key.
 
@@ -261,13 +295,16 @@ const client = computed(() => {
 ```
 
 Tricky
+
 - memo uses the first callback only. Use stable closures.
 - Use a custom key when the same callback body is used multiple times.
 
 ## Forms: base usage and reactive validation
+
 Forms are built from fields, field sets, and a submit action.
 
 Key primitives
+
 - reatomField: single field with state, value, focus, validation, disabled
 - reatomFieldSet: grouped fields with aggregate focus and validation
 - reatomForm: field set plus submit, schema validation, and form options
@@ -315,10 +352,12 @@ const registerForm = reatomForm(
 ```
 
 Reactive validation note
+
 - The validate callback tracks atoms it reads after the first trigger.
 - This enables dependent validation without manual wiring.
 
 Submit notes
+
 - submit is async and expects errors to be thrown.
 - submit.error() holds the latest error.
 - form.reset() cancels submit and resets submitted state.
@@ -355,10 +394,12 @@ export const RegisterForm = reatomComponent(() => {
 ```
 
 Tricky
+
 - Validation errors for schema are distributed by path.
 - Triggered state for field sets is true only when all fields were triggered.
 
 ## Routing + logger example (short but full-featured)
+
 This example uses routes, loaders, and logger setup for a typical SPA.
 
 ### setup.ts
@@ -482,11 +523,13 @@ export const App = reatomComponent(() => {
 ```
 
 Notes
+
 - Import setup.ts before any model to enable logger hooks.
 - Route loaders are async computed with auto-cancel.
 - Use wrap for event handlers and async boundaries.
 
 ## Suspense notes
+
 Use suspense for global initialization, not for dynamic page data.
 
 - withSuspense adds .suspended() that throws promise for Suspense.
@@ -496,6 +539,7 @@ Use suspense for global initialization, not for dynamic page data.
 - Avoid non-idempotent side effects inside withSuspenseRetry.
 
 ## Transactions notes
+
 Transactions support optimistic updates with rollback.
 
 - withRollback on atoms tracks state changes.
@@ -507,7 +551,14 @@ Transactions support optimistic updates with rollback.
 Example
 
 ```ts
-import { action, atom, withAsync, withRollback, withTransaction, wrap } from '@reatom/core'
+import {
+  action,
+  atom,
+  withAsync,
+  withRollback,
+  withTransaction,
+  wrap,
+} from '@reatom/core'
 
 type Todo = { id: string; title: string }
 
@@ -528,11 +579,13 @@ const saveTodo = action(async (todo: Todo) => {
 ```
 
 ## SSR and testing
+
 - context.start creates isolated contexts for SSR requests or tests.
 - clearStack forces explicit wrap usage, useful for strict isolation.
 - context.reset clears the default global context between tests.
 
 ## v3 migration highlights
+
 - Implicit context is default in v1000, ctx is not used.
 - ctx.schedule(promise) -> wrap(promise)
 - ctx.spy(atom) -> atom()
@@ -549,7 +602,9 @@ const saveTodo = action(async (todo: Todo) => {
 - withConcurrency -> withAbort
 
 ## Other APIs (not detailed here)
+
 Core
+
 - addGlobalExtension for global cross-cutting behavior
 - withActions for attaching methods as actions
 - withMiddleware and withParams for middleware and parameter transforms
@@ -558,6 +613,7 @@ Core
 - isAtom, isAction, isComputed, isConnected, named for introspection
 
 Extensions
+
 - withAbort for abortable actions and computeds
 - withMemo to stabilize computed outputs
 - withDynamicSubscription to avoid unnecessary connections
@@ -566,6 +622,7 @@ Extensions
 - withDisconnectHook for explicit disconnect actions
 
 Methods
+
 - abortVar and variable for async context variables
 - peek for non-reactive reads
 - schedule and retry for controlled reevaluation
@@ -575,15 +632,18 @@ Methods
 - isCausedBy to guard against self-triggered updates
 
 Routing helpers
+
 - searchParamsAtom and withSearchParams for URL search state
 - urlAtom for low-level URL control, link interception, sync hooks
 - is404 and isSomeLoaderPending for route status
 
 Primitives
+
 - reatomArray, reatomBoolean, reatomEnum, reatomNumber, reatomString
 - reatomMap, reatomSet, reatomRecord, reatomLinkedList
 
 Persistence
+
 - reatomPersist for custom storage adapters
 - withLocalStorage and withSessionStorage for web storage
 - withIndexedDb for IndexedDB persistence
@@ -592,6 +652,7 @@ Persistence
 - createMemStorage for in-memory persistence in tests
 
 Web utilities
+
 - onLineAtom for network status
 - reatomMediaQuery for media query binding
 - reatomWebSocket for websocket state
@@ -599,7 +660,9 @@ Web utilities
 - fetch wrapper for consistent context usage
 
 Render adapter
+
 - reatomAbstractRender for building framework adapters
 
 Utils
+
 - General helpers for equality, abort errors, timers, and typed helpers


### PR DESCRIPTION
Add `summary.md` to provide a comprehensive, fast-start documentation for developing SPAs with Reatom.

---
<a href="https://cursor.com/background-agent?bcId=bc-19ebff24-3f63-474d-a596-019cab96a5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19ebff24-3f63-474d-a596-019cab96a5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive `summary.md` fast-start guide for building SPAs with Reatom.
> 
> - Updates form docs: clarifies `field-atom` validation example, adds reusable `withFormAutoSubmit` and `withFormAutoFocusOnError` recipes, and improves comparison page formatting
> - Polishes persistence docs (simplified imports, IndexedDB examples)
> - Core: JSDoc/comment wraps and code style cleanups in `withAsyncData.ts`, tests (`action.test.ts`, `withSuspenseRetry.test.ts`, `retry.test.ts`), and minor typings/comment tweaks in `utils.ts` and `memo.ts`
> 
> No functional/runtime changes expected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543e768166d4fe59008db2d804446511c9492ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->