### PR TITLE
docs: fix test script in tutorial to support TypeScript execution

### DIFF
--- a/packages/eslint-plugin/eslint9-developer-llm-notes.md
+++ b/packages/eslint-plugin/eslint9-developer-llm-notes.md
@@ -434,7 +434,7 @@ Add a test script to `package.json`:
 ```json
 {
   "scripts": {
-    "test": "node enforce-foo-bar.test.ts"
+    "test": "npx tsx enforce-foo-bar.test.ts"
   }
 }
 ```


### PR DESCRIPTION
The tutorial in "Step 5" instructed users to run a TypeScript test file directly with node. This causes a SyntaxError because Node does not support TypeScript natively.

I updated the command to use npx tsx, which is the standard way to execute TS files in modern development environments without a build step. This ensures the tutorial works "out of the box" for new contributors.