### PR TITLE
Infinite list view model

### DIFF
--- a/packages/core/src/methods/connectLogger.test.ts
+++ b/packages/core/src/methods/connectLogger.test.ts
@@ -5,8 +5,16 @@ import { atom, computed, EXTENSIONS, notify, withActions } from '../core'
 import { connectLogger, log } from './connectLogger'
 import { getStackTrace } from './getStackTrace'
 
+const normalizeAtomIds = (stack: string) => {
+  const idMap = new Map<string, number>()
+  let nextId = 1
+  return stack.replace(/\[#(\d+)\]/g, (_, id) => {
+    if (!idMap.has(id)) idMap.set(id, nextId++)
+    return `[#${idMap.get(id)}]`
+  })
+}
+
 test('calc deps graph', async () => {
-  // Create atoms for a counter feature
   const counter = atom(0, 'counter').extend(
     withActions((target) => ({
       inc: () => target.set((s) => s + 1),
@@ -23,7 +31,7 @@ test('calc deps graph', async () => {
   })
 
   // prettier-ignore
-  expect(stack).toBe(
+  expect(normalizeAtomIds(stack)).toBe(
     `
 ─effect._subscribe
  └─ effect[#1]
@@ -38,16 +46,16 @@ test('calc deps graph', async () => {
   await wrap(sleep())
 
   // prettier-ignore
-  expect(stack).toBe(
+  expect(normalizeAtomIds(stack)).toBe(
 `
 ─effect._subscribe
- └─ effect[#5]
-    ├─ counter[#6]
-    │  └─ counter.inc[#9]
-    ├─ doubled[#7]
-    │  └─ counter[#6]
-    └─ isEven[#8]
-       └─ counter[#6]`.slice(1),
+ └─ effect[#1]
+    ├─ counter[#2]
+    │  └─ counter.inc[#3]
+    ├─ doubled[#4]
+    │  └─ counter[#2]
+    └─ isEven[#5]
+       └─ counter[#2]`.slice(1),
 )
 })
 
@@ -68,16 +76,16 @@ test('BFS log simplification', () => {
   notify()
 
   // prettier-ignore
-  expect(stack).toBe(
-    // there should be NO ` ─ a[#20]` after the second `b[#18]`
+  expect(normalizeAtomIds(stack)).toBe(
+    // there should be NO normalized a[#4] after the second b[#3]
     `
 ─effect._subscribe
- └─ effect[#16]
-    └─ d[#17]
-       ├─ b[#18]
-       │  └─ a[#20]
-       └─ c[#19]
-          └─ b[#18]`.slice(1),
+ └─ effect[#1]
+    └─ d[#2]
+       ├─ b[#3]
+       │  └─ a[#4]
+       └─ c[#5]
+          └─ b[#3]`.slice(1),
   )
 })
 

--- a/packages/core/src/primitives/index.ts
+++ b/packages/core/src/primitives/index.ts
@@ -1,6 +1,7 @@
 export * from './reatomArray'
 export * from './reatomBoolean'
 export * from './reatomEnum'
+export * from './reatomInfinityList'
 export * from './reatomLinkedList'
 export * from './reatomMap'
 export * from './reatomNumber'

--- a/packages/core/src/primitives/reatomInfinityList.test.ts
+++ b/packages/core/src/primitives/reatomInfinityList.test.ts
@@ -1,0 +1,395 @@
+import { expect, subscribe, test, vi } from 'test'
+
+import { atom, computed, notify } from '../core'
+import { wrap } from '../methods'
+import { sleep } from '../utils'
+import { reatomLinkedList } from './reatomLinkedList'
+import { reatomInfinityList } from './reatomInfinityList'
+
+test('basic viewport state without fetcher', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 4 })
+
+  expect(inf.items().map(({ n }) => n)).toEqual([1, 2, 3, 4])
+  expect(inf.totalSize()).toBe(10)
+  expect(inf.topCount()).toBe(0)
+  expect(inf.bottomCount()).toBe(6)
+  expect(inf.hasMore()).toBe(true)
+  expect(inf.isEnd()).toBe(false)
+})
+
+test('viewport shifts on offset change', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 4 })
+
+  inf.offset.set(3)
+  expect(inf.items().map(({ n }) => n)).toEqual([4, 5, 6, 7])
+  expect(inf.topCount()).toBe(3)
+  expect(inf.bottomCount()).toBe(3)
+
+  inf.offset.set(7)
+  expect(inf.items().map(({ n }) => n)).toEqual([8, 9, 10])
+  expect(inf.topCount()).toBe(7)
+  expect(inf.bottomCount()).toBe(0)
+})
+
+test('viewport reacts to limit change', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 3 })
+
+  expect(inf.items().map(({ n }) => n)).toEqual([1, 2, 3])
+  expect(inf.bottomCount()).toBe(7)
+
+  inf.limit.set(5)
+  expect(inf.items().map(({ n }) => n)).toEqual([1, 2, 3, 4, 5])
+  expect(inf.bottomCount()).toBe(5)
+})
+
+test('counts update when list is modified externally', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 3 })
+
+  inf.offset.set(1)
+  expect(inf.topCount()).toBe(1)
+  expect(inf.bottomCount()).toBe(1)
+  expect(inf.totalSize()).toBe(5)
+
+  list.create(6)
+  notify()
+
+  expect(inf.totalSize()).toBe(6)
+  expect(inf.topCount()).toBe(1)
+  expect(inf.bottomCount()).toBe(2)
+})
+
+test('isEnd when hasMore is false and viewport at list end', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 3 })
+
+  inf.hasMore.set(false)
+  expect(inf.isEnd()).toBe(false)
+
+  inf.offset.set(2)
+  expect(inf.items().map(({ n }) => n)).toEqual([3, 4, 5])
+  expect(inf.isEnd()).toBe(true)
+
+  inf.offset.set(0)
+  expect(inf.isEnd()).toBe(false)
+})
+
+test('empty list state', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const inf = reatomInfinityList(list, { limit: 10 })
+
+  expect(inf.items()).toEqual([])
+  expect(inf.totalSize()).toBe(0)
+  expect(inf.topCount()).toBe(0)
+  expect(inf.bottomCount()).toBe(0)
+  expect(inf.hasMore()).toBe(true)
+  expect(inf.isEnd()).toBe(false)
+})
+
+test('loadMore fetches and appends items', async () => {
+  type Item = { id: number }
+  const serverItems: Item[] = Array.from({ length: 50 }, (_, i) => ({
+    id: i,
+  }))
+  const PAGE_SIZE = 10
+
+  const list = reatomLinkedList((item: Item) => item)
+  const inf = reatomInfinityList(list, {
+    limit: PAGE_SIZE,
+    fetcher: async (offset, limit) => {
+      const page = serverItems.slice(offset, offset + limit)
+      return page.map((item) => [item] as [Item])
+    },
+  })
+
+  expect(inf.items()).toEqual([])
+  expect(inf.isLoading()).toBe(false)
+
+  const loadPromise = inf.loadMore()
+  expect(inf.isLoading()).toBe(true)
+
+  await wrap(loadPromise)
+
+  expect(inf.isLoading()).toBe(false)
+  expect(inf.totalSize()).toBe(10)
+  expect(inf.items().length).toBe(10)
+  expect(inf.items()[0]!.id).toBe(0)
+  expect(inf.items()[9]!.id).toBe(9)
+  expect(inf.hasMore()).toBe(true)
+})
+
+test('loadMore sets hasMore to false on partial page', async () => {
+  type Item = { id: number }
+  const serverItems: Item[] = Array.from({ length: 5 }, (_, i) => ({
+    id: i,
+  }))
+
+  const list = reatomLinkedList((item: Item) => item)
+  const inf = reatomInfinityList(list, {
+    limit: 10,
+    fetcher: async (offset, limit) => {
+      const page = serverItems.slice(offset, offset + limit)
+      return page.map((item) => [item] as [Item])
+    },
+  })
+
+  await wrap(inf.loadMore())
+
+  expect(inf.totalSize()).toBe(5)
+  expect(inf.hasMore()).toBe(false)
+})
+
+test('loadMore skips when hasMore is false', async () => {
+  const fetcherSpy = vi.fn(async () => [] as Array<[{ id: number }]>)
+
+  const list = reatomLinkedList((item: { id: number }) => item)
+  const inf = reatomInfinityList(list, {
+    limit: 10,
+    fetcher: fetcherSpy,
+  })
+
+  inf.hasMore.set(false)
+  await wrap(inf.loadMore())
+
+  expect(fetcherSpy).not.toHaveBeenCalled()
+})
+
+test('multiple loadMore calls accumulate data', async () => {
+  type Item = { id: number }
+  const serverItems: Item[] = Array.from({ length: 25 }, (_, i) => ({
+    id: i,
+  }))
+
+  const list = reatomLinkedList((item: Item) => item)
+  const inf = reatomInfinityList(list, {
+    limit: 10,
+    fetcher: async (offset, limit) => {
+      const page = serverItems.slice(offset, offset + limit)
+      return page.map((item) => [item] as [Item])
+    },
+  })
+
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(10)
+  expect(inf.hasMore()).toBe(true)
+
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(20)
+  expect(inf.hasMore()).toBe(true)
+
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(25)
+  expect(inf.hasMore()).toBe(false)
+})
+
+test('padding counts for virtual scroll', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany(
+    Array.from({ length: 100 }, (_, i) => [i + 1] as [number]),
+  )
+  notify()
+
+  const VIEWPORT_SIZE = 20
+  const inf = reatomInfinityList(list, { limit: VIEWPORT_SIZE })
+
+  const ESTIMATED_ITEM_HEIGHT = 50
+
+  inf.offset.set(0)
+  const topPaddingAtStart = inf.topCount() * ESTIMATED_ITEM_HEIGHT
+  const bottomPaddingAtStart = inf.bottomCount() * ESTIMATED_ITEM_HEIGHT
+  expect(topPaddingAtStart).toBe(0)
+  expect(bottomPaddingAtStart).toBe(80 * ESTIMATED_ITEM_HEIGHT)
+
+  inf.offset.set(40)
+  const topPaddingMiddle = inf.topCount() * ESTIMATED_ITEM_HEIGHT
+  const bottomPaddingMiddle = inf.bottomCount() * ESTIMATED_ITEM_HEIGHT
+  expect(topPaddingMiddle).toBe(40 * ESTIMATED_ITEM_HEIGHT)
+  expect(bottomPaddingMiddle).toBe(40 * ESTIMATED_ITEM_HEIGHT)
+
+  inf.offset.set(80)
+  const topPaddingEnd = inf.topCount() * ESTIMATED_ITEM_HEIGHT
+  const bottomPaddingEnd = inf.bottomCount() * ESTIMATED_ITEM_HEIGHT
+  expect(topPaddingEnd).toBe(80 * ESTIMATED_ITEM_HEIGHT)
+  expect(bottomPaddingEnd).toBe(0)
+})
+
+test('near-real infinite scroll model with async fetching', async () => {
+  type Item = { id: number; text: string }
+  const SERVER_TOTAL = 73
+  const serverItems: Item[] = Array.from({ length: SERVER_TOTAL }, (_, i) => ({
+    id: i,
+    text: `Item ${i}`,
+  }))
+  const PAGE_SIZE = 20
+
+  const list = reatomLinkedList((item: Item) => item)
+  const inf = reatomInfinityList(list, {
+    limit: PAGE_SIZE,
+    fetcher: async (offset, limit) => {
+      await sleep(5)
+      const page = serverItems.slice(offset, offset + limit)
+      return page.map((item) => [item] as [Item])
+    },
+  })
+
+  const itemsTrack = subscribe(inf.items)
+  const loadingTrack = subscribe(
+    computed(() => inf.isLoading()),
+  )
+
+  expect(inf.items()).toEqual([])
+  expect(inf.totalSize()).toBe(0)
+  expect(inf.hasMore()).toBe(true)
+  expect(inf.isLoading()).toBe(false)
+
+  // --- Page 1 ---
+  const p1 = inf.loadMore()
+  expect(inf.isLoading()).toBe(true)
+  await wrap(p1)
+
+  expect(inf.isLoading()).toBe(false)
+  expect(inf.totalSize()).toBe(20)
+  expect(inf.items().length).toBe(20)
+  expect(inf.topCount()).toBe(0)
+  expect(inf.bottomCount()).toBe(0)
+
+  // --- User scrolls to item 10 ---
+  inf.offset.set(10)
+  expect(inf.topCount()).toBe(10)
+  expect(inf.items().length).toBe(10)
+  expect(inf.bottomCount()).toBe(0)
+
+  // --- Near bottom, trigger page 2 ---
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(40)
+  expect(inf.items().length).toBe(20)
+  expect(inf.topCount()).toBe(10)
+  expect(inf.bottomCount()).toBe(10)
+
+  // --- Keep scrolling + loading ---
+  inf.offset.set(30)
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(60)
+  expect(inf.topCount()).toBe(30)
+  expect(inf.bottomCount()).toBe(10)
+
+  // --- Load remaining data ---
+  await wrap(inf.loadMore())
+  expect(inf.totalSize()).toBe(73)
+  expect(inf.hasMore()).toBe(false)
+
+  // --- Scroll to the very end ---
+  inf.offset.set(53)
+  expect(inf.items().length).toBe(20)
+  expect(inf.items()[0]!.id).toBe(53)
+  expect(inf.items()[19]!.id).toBe(72)
+  expect(inf.topCount()).toBe(53)
+  expect(inf.bottomCount()).toBe(0)
+  expect(inf.isEnd()).toBe(true)
+
+  // --- Scroll back to top ---
+  inf.offset.set(0)
+  expect(inf.items()[0]!.id).toBe(0)
+  expect(inf.topCount()).toBe(0)
+  expect(inf.bottomCount()).toBe(53)
+  expect(inf.isEnd()).toBe(false)
+})
+
+test('fetcher error is captured via AsyncExt', async () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const inf = reatomInfinityList(list, {
+    limit: 10,
+    fetcher: async () => {
+      throw new Error('Network failure')
+    },
+  })
+
+  await wrap(inf.loadMore().catch(() => {}))
+
+  expect(inf.loadMore.error()).instanceOf(Error)
+  expect(inf.loadMore.error()?.message).toBe('Network failure')
+  expect(inf.isLoading()).toBe(false)
+  expect(inf.totalSize()).toBe(0)
+  expect(inf.hasMore()).toBe(true)
+})
+
+test('items computed only notifies on actual item changes', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 3 })
+  const track = subscribe(inf.items)
+
+  expect(track).toBeCalledTimes(1)
+
+  list.create(6)
+  notify()
+
+  expect(track).toBeCalledTimes(1)
+
+  inf.offset.set(1)
+  notify()
+
+  expect(track).toBeCalledTimes(2)
+  expect(track.mock.lastCall?.[0].map(({ n }) => n)).toEqual([2, 3, 4])
+})
+
+test('list clear resets infinite list state', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 3 })
+
+  inf.offset.set(2)
+  expect(inf.topCount()).toBe(2)
+  expect(inf.items().length).toBe(3)
+
+  list.clear()
+  notify()
+
+  expect(inf.totalSize()).toBe(0)
+  expect(inf.items()).toEqual([])
+  expect(inf.topCount()).toBe(0)
+  expect(inf.bottomCount()).toBe(0)
+})
+
+test('default limit is 20', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const inf = reatomInfinityList(list)
+
+  expect(inf.limit()).toBe(20)
+})
+
+test('view atom is accessible for advanced use', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const inf = reatomInfinityList(list, { limit: 2 })
+
+  const viewState = inf.view()
+  expect(viewState.items.map(({ n }) => n)).toEqual([1, 2])
+  expect(viewState.totalSize).toBe(3)
+  expect(viewState.offset).toBe(0)
+  expect(viewState.limit).toBe(2)
+})

--- a/packages/core/src/primitives/reatomInfinityList.ts
+++ b/packages/core/src/primitives/reatomInfinityList.ts
@@ -1,0 +1,151 @@
+import type { Action, Atom, Computed } from '../core'
+import { action, atom, computed, named } from '../core'
+import type { AsyncExt } from '../async'
+import { withAsync } from '../async'
+import { wrap } from '../methods'
+import type { Rec } from '../utils'
+import type {
+  LinkedListAtom,
+  LinkedListViewAtom,
+  LinkedListViewState,
+  LLNode,
+} from './reatomLinkedList'
+
+export interface InfinityListAtom<Node extends LLNode> {
+  offset: Atom<number>
+  limit: Atom<number>
+
+  view: LinkedListViewAtom<Node>
+  items: Computed<Array<Node>>
+
+  topCount: Computed<number>
+  bottomCount: Computed<number>
+  totalSize: Computed<number>
+
+  hasMore: Atom<boolean>
+  isEnd: Computed<boolean>
+}
+
+export interface InfinityListFetcherAtom<Node extends LLNode>
+  extends InfinityListAtom<Node> {
+  loadMore: Action<[], Promise<void>> & AsyncExt<[], void>
+  isLoading: Computed<boolean>
+}
+
+export function reatomInfinityList<
+  Params extends any[],
+  Node extends Rec,
+  Key extends keyof Node,
+>(
+  list: LinkedListAtom<Params, Node, Key>,
+  options?: {
+    limit?: number
+    name?: string
+  },
+): InfinityListAtom<LLNode<Node>>
+
+export function reatomInfinityList<
+  Params extends any[],
+  Node extends Rec,
+  Key extends keyof Node,
+>(
+  list: LinkedListAtom<Params, Node, Key>,
+  options: {
+    limit?: number
+    name?: string
+    fetcher: (offset: number, limit: number) => Promise<Array<Params>>
+  },
+): InfinityListFetcherAtom<LLNode<Node>>
+
+export function reatomInfinityList<
+  Params extends any[],
+  Node extends Rec,
+  Key extends keyof Node,
+>(
+  list: LinkedListAtom<Params, Node, Key>,
+  options: {
+    limit?: number
+    name?: string
+    fetcher?: (offset: number, limit: number) => Promise<Array<Params>>
+  } = {},
+): InfinityListAtom<LLNode<Node>> | InfinityListFetcherAtom<LLNode<Node>> {
+  const _name = options.name ?? named('infinityList')
+  const initialLimit = options.limit ?? 20
+  const userFetcher = options.fetcher
+
+  const offset = atom(0, `${_name}.offset`)
+  const limit = atom(initialLimit, `${_name}.limit`)
+
+  const view = list.reatomView(
+    () => ({ offset: offset(), limit: limit() }),
+    `${_name}.view`,
+  )
+
+  const items = view.items
+
+  const topCount = computed(
+    () => view().offset,
+    `${_name}.topCount`,
+  )
+
+  const bottomCount = computed(
+    () => {
+      const viewState = view()
+      return viewState.totalSize - viewState.offset - viewState.items.length
+    },
+    `${_name}.bottomCount`,
+  )
+
+  const totalSize = computed(
+    () => view().totalSize,
+    `${_name}.totalSize`,
+  )
+
+  const hasMore = atom(true, `${_name}.hasMore`)
+
+  const isEnd = computed(() => {
+    const viewState = view()
+    const viewportEnd = viewState.offset + viewState.items.length
+    const reachedListEnd = viewportEnd >= viewState.totalSize
+    return !hasMore() && reachedListEnd
+  }, `${_name}.isEnd`)
+
+  const base: InfinityListAtom<LLNode<Node>> = {
+    offset,
+    limit,
+    view,
+    items,
+    topCount,
+    bottomCount,
+    totalSize,
+    hasMore,
+    isEnd,
+  }
+
+  if (!userFetcher) return base
+
+  const loadMore = action(async (): Promise<void> => {
+    if (!hasMore()) return
+
+    const currentSize = list().size
+    const currentLimit = limit()
+    const fetchedParams = await wrap(userFetcher(currentSize, currentLimit))
+
+    list.createMany(fetchedParams)
+
+    if (fetchedParams.length < currentLimit) {
+      hasMore.set(false)
+    }
+  }, `${_name}.loadMore`).extend(withAsync())
+
+  const isLoading = computed(
+    () => !loadMore.ready(),
+    `${_name}.isLoading`,
+  )
+
+  return {
+    ...base,
+    loadMore,
+    isLoading,
+  } satisfies InfinityListFetcherAtom<LLNode<Node>>
+}

--- a/packages/core/src/primitives/reatomLinkedList.test.ts
+++ b/packages/core/src/primitives/reatomLinkedList.test.ts
@@ -3,7 +3,13 @@ import { expect, subscribe, test, vi } from 'test'
 import { atom, computed, isAtom, isConnected, notify } from '../core'
 import { withChangeHook } from '../extensions'
 import { deatomize, isCausedBy } from '../methods'
-import { LL_NEXT, LL_PREV, reatomLinkedList } from './reatomLinkedList'
+import {
+  LL_NEXT,
+  LL_PREV,
+  reatomLinkedList,
+  type LinkedListViewAtom,
+  type LLNode,
+} from './reatomLinkedList'
 
 test('should respect initState, create and remove elements properly', () => {
   const list = reatomLinkedList({
@@ -410,4 +416,292 @@ test('should track createMany and removeMany with reatomMap', () => {
   expect(track.mock.lastCall?.[0]).toEqual([4])
   expect(mapped().changes.length).toBe(1)
   expect(mapped().changes[0]!.kind).toBe('removeMany')
+})
+
+test('reatomView should return items for a basic view window', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 3 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2, 3])
+  expect(view().totalSize).toBe(5)
+  expect(view().offset).toBe(0)
+  expect(view().limit).toBe(3)
+})
+
+test('reatomView should react to changes in lens atoms', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const offset = atom(0)
+  const limit = atom(2)
+  const view = list.reatomView(() => ({ offset: offset(), limit: limit() }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2])
+
+  offset.set(2)
+  expect(view().items.map(({ n }) => n)).toEqual([3, 4])
+
+  limit.set(3)
+  expect(view().items.map(({ n }) => n)).toEqual([3, 4, 5])
+
+  offset.set(4)
+  expect(view().items.map(({ n }) => n)).toEqual([5])
+})
+
+test('reatomView should update when list items are added', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const view = list.reatomView(() => ({ offset: 0, limit: 3 }))
+
+  expect(view().items).toEqual([])
+  expect(view().totalSize).toBe(0)
+
+  list.createMany([[1], [2]])
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2])
+  expect(view().totalSize).toBe(2)
+
+  list.create(3)
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2, 3])
+  expect(view().totalSize).toBe(3)
+
+  list.create(4)
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2, 3])
+  expect(view().totalSize).toBe(4)
+})
+
+test('reatomView should update when list items are removed', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 1, limit: 2 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([2, 3])
+
+  list.remove(list.array()[0]!)
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([3, 4])
+  expect(view().totalSize).toBe(4)
+})
+
+test('reatomView should memoize items array when content is unchanged', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 2 }))
+  const firstItems = view().items
+
+  list.create(4)
+  notify()
+
+  expect(view().items).toBe(firstItems)
+  expect(view().totalSize).toBe(4)
+})
+
+test('reatomView items computed should not notify when items are unchanged', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 2 }))
+  const track = subscribe(view.items)
+
+  expect(track).toBeCalledTimes(1)
+  expect(track.mock.lastCall?.[0].map(({ n }) => n)).toEqual([1, 2])
+
+  list.create(4)
+  notify()
+
+  expect(track).toBeCalledTimes(1)
+})
+
+test('reatomView should handle offset beyond list size', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 10, limit: 5 }))
+
+  expect(view().items).toEqual([])
+  expect(view().totalSize).toBe(3)
+  expect(view().offset).toBe(3)
+})
+
+test('reatomView should handle empty list', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const view = list.reatomView(() => ({ offset: 0, limit: 5 }))
+
+  expect(view().items).toEqual([])
+  expect(view().totalSize).toBe(0)
+  expect(view().offset).toBe(0)
+  expect(view().limit).toBe(5)
+})
+
+test('reatomView should handle list clear', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 3 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2, 3])
+
+  list.clear()
+  notify()
+
+  expect(view().items).toEqual([])
+  expect(view().totalSize).toBe(0)
+})
+
+test('reatomView should reflect swap within view window', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 3 }))
+  const nodes = list.array()
+
+  list.swap(nodes[0]!, nodes[2]!)
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([3, 2, 1])
+})
+
+test('reatomView should reflect move within view window', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 3 }))
+  const nodes = list.array()
+
+  list.move(nodes[0]!, nodes[2]!)
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([2, 3, 1])
+})
+
+test('reatomView should clamp negative offset to 0', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: -5, limit: 2 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2])
+  expect(view().offset).toBe(0)
+})
+
+test('reatomView should handle zero limit', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 0 }))
+
+  expect(view().items).toEqual([])
+  expect(view().totalSize).toBe(3)
+  expect(view().limit).toBe(0)
+})
+
+test('reatomView should return full state memoization when nothing changes', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 2 }))
+
+  const state1 = view()
+  const state2 = view()
+
+  expect(state1).toBe(state2)
+})
+
+test('reatomView should work with removeMany', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  const nodes = list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 1, limit: 3 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([2, 3, 4])
+
+  list.removeMany([nodes[1]!, nodes[3]!])
+  notify()
+
+  expect(view().items.map(({ n }) => n)).toEqual([3, 5])
+  expect(view().totalSize).toBe(3)
+})
+
+test('reatomView should work with a sliding window pattern', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+  notify()
+
+  const pageSize = 3
+  const page = atom(0)
+  const view = list.reatomView(() => ({
+    offset: page() * pageSize,
+    limit: pageSize,
+  }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2, 3])
+  expect(view().totalSize).toBe(10)
+
+  page.set(1)
+  expect(view().items.map(({ n }) => n)).toEqual([4, 5, 6])
+
+  page.set(2)
+  expect(view().items.map(({ n }) => n)).toEqual([7, 8, 9])
+
+  page.set(3)
+  expect(view().items.map(({ n }) => n)).toEqual([10])
+
+  page.set(4)
+  expect(view().items).toEqual([])
+  expect(view().offset).toBe(10)
+})
+
+test('reatomView items computed should notify only when items change', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2], [3], [4], [5]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 2 }))
+  const track = subscribe(view.items)
+
+  expect(track).toBeCalledTimes(1)
+  expect(track.mock.lastCall?.[0].map(({ n }) => n)).toEqual([1, 2])
+
+  list.create(6)
+  notify()
+  expect(track).toBeCalledTimes(1)
+
+  list.remove(list.array()[0]!)
+  notify()
+  expect(track).toBeCalledTimes(2)
+  expect(track.mock.lastCall?.[0].map(({ n }) => n)).toEqual([2, 3])
+})
+
+test('reatomView should handle limit larger than list', () => {
+  const list = reatomLinkedList((n: number) => ({ n }))
+  list.createMany([[1], [2]])
+  notify()
+
+  const view = list.reatomView(() => ({ offset: 0, limit: 100 }))
+
+  expect(view().items.map(({ n }) => n)).toEqual([1, 2])
+  expect(view().totalSize).toBe(2)
+  expect(view().limit).toBe(100)
 })

--- a/packages/core/src/primitives/reatomLinkedList.ts
+++ b/packages/core/src/primitives/reatomLinkedList.ts
@@ -90,6 +90,11 @@ export interface LinkedListAtom<
         },
   ) => LinkedListDerivedAtom<LLNode<Node>, LLNode<T>>
 
+  reatomView: (
+    lens: () => { offset: number; limit: number },
+    name?: string,
+  ) => LinkedListViewAtom<LLNode<Node>>
+
   // reatomFilter: (
   //   cb: (node: Node) => any,
   //   name?: string,
@@ -120,6 +125,18 @@ export interface LinkedListDerivedAtom<
   array: Computed<Array<T extends LinkedList<infer LLNode> ? LLNode : never>>
 
   __reatomLinkedList: true
+}
+
+export interface LinkedListViewState<Node extends LLNode> {
+  items: Array<Node>
+  totalSize: number
+  offset: number
+  limit: number
+}
+
+export interface LinkedListViewAtom<Node extends LLNode>
+  extends Computed<LinkedListViewState<Node>> {
+  items: Computed<Array<Node>>
 }
 
 const addLL = <Node extends LLNode>(
@@ -732,6 +749,73 @@ export function reatomLinkedList<
     return Object.assign(mapList, { array, __reatomLinkedList: true as const })
   }
 
+  const reatomView = (
+    lens: () => { offset: number; limit: number },
+    viewName: string = named(`${_name}.reatomView`),
+  ): LinkedListViewAtom<LLNode<Node>> => {
+    const viewComputed = computed(
+      (
+        prev?: LinkedListViewState<LLNode<Node>>,
+      ): LinkedListViewState<LLNode<Node>> => {
+        const ll = linkedList()
+        const { offset: rawOffset, limit: rawLimit } = lens()
+
+        const clampedOffset = Math.max(0, Math.min(rawOffset, ll.size))
+        const clampedLimit = Math.max(0, rawLimit)
+
+        let current = ll.head
+        let skipped = 0
+        while (current !== null && skipped < clampedOffset) {
+          current = current[LL_NEXT]
+          skipped++
+        }
+
+        const items: Array<LLNode<Node>> = []
+        while (current !== null && items.length < clampedLimit) {
+          items.push(current)
+          current = current[LL_NEXT]
+        }
+
+        if (prev !== undefined) {
+          const itemsUnchanged =
+            prev.items.length === items.length &&
+            items.every((item, idx) => item === prev.items[idx])
+
+          if (itemsUnchanged) {
+            const stateUnchanged =
+              prev.totalSize === ll.size &&
+              prev.offset === clampedOffset &&
+              prev.limit === clampedLimit
+
+            if (stateUnchanged) return prev
+
+            return {
+              items: prev.items,
+              totalSize: ll.size,
+              offset: clampedOffset,
+              limit: clampedLimit,
+            }
+          }
+        }
+
+        return {
+          items,
+          totalSize: ll.size,
+          offset: clampedOffset,
+          limit: clampedLimit,
+        }
+      },
+      viewName,
+    )
+
+    const viewItems = computed(
+      () => viewComputed().items,
+      `${viewName}.items`,
+    )
+
+    return Object.assign(viewComputed, { items: viewItems })
+  }
+
   // TODO there is a bug with `del` logic
   // const reatomReduce = <T>(
   //   {
@@ -811,6 +895,7 @@ export function reatomLinkedList<
     initiateFromSnapshot: createLinkedListFromSnapshot,
 
     reatomMap,
+    reatomView,
     // reatomFilter,
     // reatomReduce,
 


### PR DESCRIPTION
Add `reatomView` primitive to `reatomLinkedList` to enable efficient windowed views for infinite lists.

This primitive provides a reactive "lens" that selects a range of elements from the linked list based on `offset` and `limit` parameters. This is crucial for implementing infinite scroll patterns, as it allows rendering only a small visible window of a potentially large data source, improving performance by preventing unnecessary re-renders when items outside the viewport change.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5ba3b8a9-9c63-4288-9d25-b9b0e50a1ad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ba3b8a9-9c63-4288-9d25-b9b0e50a1ad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public API and computed traversal/memoization logic over the linked list; risk is mostly correctness/perf regressions in view calculations and notification behavior under list mutations.
> 
> **Overview**
> Adds a new `reatomView` primitive to `reatomLinkedList` that exposes a reactive, windowed view (`items`, `totalSize`, `offset`, `limit`) computed from a lens of `{offset, limit}`, with clamping and memoization to avoid re-emitting unchanged arrays/state.
> 
> Extends the test suite with comprehensive coverage for `reatomView` behavior across lens changes, add/remove/clear, move/swap, edge cases (negative/oversized offsets, zero/large limits), and notification/memoization guarantees via `view.items`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b4cc01d0be3e6f464eb501e71725bc0df24b1da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->