### PR TITLE
test(persist): add failing tests for URL atom sync via persist

### DIFF
--- a/packages/core/src/persist/index.test.ts
+++ b/packages/core/src/persist/index.test.ts
@@ -207,3 +207,47 @@ describe('should not accept an action', () => {
     expect(() => testAction.extend(withSomePersist('test'))).toThrow()
   })
 })
+
+describe('URL atom persist', () => {
+  test('should restore URL from string snapshot', () => {
+    // When a URL atom is persisted to localStorage, JSON.stringify converts
+    // URL to a string via URL.toJSON() (which returns href).
+    // This simulates reading back that serialized data.
+    withSomePersist.storageAtom.set(
+      createMemStorage({
+        name: 'test',
+        snapshot: {
+          url: 'https://example.com/page',
+        },
+      }),
+    )
+
+    const urlAtom = atom(new URL('https://example.com/'), 'urlAtom').extend(
+      withSomePersist('url'),
+    )
+
+    // After restoring from persist, the value should be a URL, not a string
+    expect(urlAtom()).toBeInstanceOf(URL)
+    expect(urlAtom().href).toBe('https://example.com/page')
+  })
+
+  test('should sync URL between atoms via shared storage', () => {
+    // Simulates cross-tab sync: two atoms sharing the same persist key.
+    // When atom1 sets a URL, atom2 should receive a proper URL object.
+    const urlAtom1 = atom(new URL('https://example.com/'), 'urlAtom1').extend(
+      withSomePersist({ key: 'url-sync' }),
+    )
+    const urlAtom2 = atom(new URL('https://example.com/'), 'urlAtom2').extend(
+      withSomePersist({ key: 'url-sync' }),
+    )
+
+    const track = subscribe(urlAtom2)
+    track.mockClear()
+
+    urlAtom1.set(new URL('https://example.com/new-page'))
+
+    // urlAtom2 should receive the update as a proper URL object
+    expect(urlAtom2()).toBeInstanceOf(URL)
+    expect(urlAtom2().href).toBe('https://example.com/new-page')
+  })
+})

--- a/packages/core/src/persist/web-storage/broadcastChannel.test.browser.ts
+++ b/packages/core/src/persist/web-storage/broadcastChannel.test.browser.ts
@@ -1,6 +1,6 @@
-import { expect, test, vi } from 'test'
+import { expect, test, vi, viTest } from 'test'
 
-import { atom } from '../../core'
+import { atom, context, notify } from '../../core'
 import {
   reatomPersistBroadcastChannel,
   withBroadcastChannel,
@@ -131,3 +131,47 @@ test('BroadcastChannel fallback when unavailable', () => {
   testAtom.set('fallback-value')
   expect(testAtom()).toBe('fallback-value')
 })
+
+viTest(
+  'BroadcastChannel cross-tab URL sync',
+  () =>
+    context.start(async () => {
+      // Simulate two tabs: channel1 sends, channel2 receives.
+      // Two BroadcastChannel instances with the same name deliver messages
+      // to each other but not to themselves.
+      const channel1 = new BroadcastChannel('url-cross-tab-test')
+      const channel2 = new BroadcastChannel('url-cross-tab-test')
+
+      const tab1Adapter = reatomPersistBroadcastChannel(channel1)
+      const tab2Adapter = reatomPersistBroadcastChannel(channel2)
+
+      const urlInTab1 = atom(
+        new URL('https://example.com/'),
+        'urlInTab1',
+      ).extend(tab1Adapter('url'))
+      const urlInTab2 = atom(
+        new URL('https://example.com/'),
+        'urlInTab2',
+      ).extend(tab2Adapter('url'))
+
+      // Subscribe to tab2 atom to activate BroadcastChannel listener
+      urlInTab2.subscribe()
+
+      // Flush effect queue so withConnectHook registers the BC listener
+      notify()
+
+      // Tab 1 navigates to a new URL (this broadcasts via channel1)
+      urlInTab1.set(new URL('https://example.com/new-page'))
+
+      // Wait for BroadcastChannel async message delivery
+      await new Promise((r) => setTimeout(r, 100))
+
+      // Tab 2 should have received the URL update as a proper URL object
+      expect(urlInTab2()).toBeInstanceOf(URL)
+      expect(urlInTab2().href).toBe('https://example.com/new-page')
+
+      channel1.close()
+      channel2.close()
+    }),
+  { timeout: 5000 },
+)

--- a/packages/core/src/persist/web-storage/localStorage.test.browser.ts
+++ b/packages/core/src/persist/web-storage/localStorage.test.browser.ts
@@ -100,6 +100,32 @@ test('storage error handling', () => {
   consoleSpy.mockRestore()
 })
 
+test('URL atom should restore as URL from localStorage', () => {
+  const key = 'test-url-key'
+
+  // When a URL is persisted to localStorage, JSON.stringify(url) calls
+  // URL.toJSON() which returns the href string. This simulates reading back
+  // that serialized data (e.g. from another tab or after page reload).
+  localStorage.setItem(
+    key,
+    JSON.stringify({
+      data: 'https://example.com/page',
+      id: 1,
+      timestamp: Date.now(),
+      to: Date.now() + 10000,
+      version: 0,
+    }),
+  )
+
+  const urlAtom = atom(new URL('https://example.com/'), 'urlAtom').extend(
+    withLocalStorage(key),
+  )
+
+  // The atom should have a URL object, not a string
+  expect(urlAtom()).toBeInstanceOf(URL)
+  expect(urlAtom().href).toBe('https://example.com/page')
+})
+
 test('fromSnapshot and toSnapshot', () => {
   const key = 'test-map-key'
 


### PR DESCRIPTION
urlAtom.extend(withBroadcastChannel('url')) and withLocalStorage don't properly synchronize URL objects. The default fromSnapshot (identity) returns a string instead of a URL when data passes through JSON serialization. Additionally, cross-tab sync via shared storage doesn't propagate URL updates between atoms.