### PR TITLE
fix: use correct variable in package generator log message

### DIFF
--- a/tools/new-package.ts
+++ b/tools/new-package.ts
@@ -36,7 +36,7 @@ async function main() {
     `❓ What is your GitHub username [${authorNameDefault}]? `,
   )
   authorName = authorName.trim() || authorNameDefault
-  console.log(`ℹ️ Author username is "${pkgName}"`)
+  console.log(`ℹ️ Author username is "${authorName}"`)
 
   const pkg = path.join(process.cwd(), 'packages', pkgName)
   await fs.promises.cp(templatePath, pkg, { recursive: true })


### PR DESCRIPTION
## Summary
- The package generator's author username log on line 39 of `tools/new-package.ts` printed `pkgName` instead of `authorName`, showing the package name as the author.

## Reproduction
```
❓ What is your GitHub username [Dmitry Sinev]? astartsky
ℹ️ Author username is "opentelemetry"   <-- should be "astartsky"
```

## Fix
Replace `pkgName` with `authorName` in the log template literal.